### PR TITLE
chore(release): bump version to 0.2.24

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """BlitztextLinux app package."""
 
 # Single source of truth for the application version.
-__version__ = "0.2.23"
+__version__ = "0.2.24"


### PR DESCRIPTION
## Was

Hebt die App-Version von `0.2.23` auf `0.2.24` an (`app/__init__.py`, Single Source of Truth).

## Warum

Nach dem Merge von Paket C + Secret-Hygiene (PR #3, Squash `f74b45b`) stand die Code-Version noch auf `0.2.23`, während das bestehende Tag `v0.2.23` auf einen älteren Commit zeigt. Dieser Bump richtet Code-Version und das anschließende Release-Tag `v0.2.24` aufeinander aus.

## Tests

- `python3 -m compileall app`
- `pytest tests/test_version.py -q` → 1 passed (Semver-Format)
- `git diff --check` → sauber

## Nächster Schritt

Nach Merge wird `v0.2.24` auf den Merge-Commit gesetzt und gepusht.