### PR TITLE
chore(release): bump version to 0.2.25

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """BlitztextLinux app package."""
 
 # Single source of truth for the application version.
-__version__ = "0.2.24"
+__version__ = "0.2.25"


### PR DESCRIPTION
## What changed?

Release bump `0.2.24 → 0.2.25` in `app/__init__.py` (single source of truth for the app version) — ships **Paket D: writing style presets** (PR #5, already merged to `main`).

## Why?

Versioniert den Paket-D-Stand für ein GitHub-Release, analog zum Paket-C-Bump (#4).

## How did you test it?

- `QT_QPA_PLATFORM=offscreen WHISPER_GUI_TESTS=1 pytest -q tests/test_version.py` → 1 passed (semver-Format).
- Volle Suite auf `main` nach Paket-D-Merge: 182 passed.

## AI assistance

Yes — Claude Code; Review durch Codex (read-only) + code-reviewer/security-reviewer.

## Checklist

- [x] I ran `pytest tests/` (offscreen) or explained why not.
- [x] I did not commit API keys, tokens, private recordings, or confidential transcripts.
- [x] I considered whether this changes privacy, security, or data flow.
- [x] I kept the change focused on the Linux scope.
