### PR TITLE
chore(release): bump version to 0.3.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """BlitztextLinux app package."""
 
 # Single source of truth for the application version.
-__version__ = "0.2.25"
+__version__ = "0.3.0"


### PR DESCRIPTION
Bündelt die seit `v0.2.25` in `main` gemergten Änderungen für den Release `v0.3.0`.
Nur Versions-Bump in `app/__init__.py` (0.2.25 → 0.3.0), keine Logikänderung.

**Enthaltene PRs:** #7 OpenRouter-LLM · #8 Layout-Fix KI-Tab · #9 Launch-Smoke-Test · #10 OpenAI Cloud-TTS

CI auf `main` grün (Python 3.11 & 3.12, Secret-Scan, GitGuardian).

**Vergleich:** v0.2.25...release/v0.3.0