### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """BlitztextLinux app package."""
 
 # Single source of truth for the application version.
-__version__ = "0.4.0"
+__version__ = "0.5.0"


### PR DESCRIPTION
## Release v0.5.0

Reiner Release-PR: bumpt nur `app/__init__.py` von `0.4.0` → `0.5.0` (Single Source of Truth). Keine weiteren Code-Änderungen.

### Gebündelter Inhalt

v0.5.0 bündelt den **Audio-Export** aus PR #18 (bereits auf `main` als `2c72c30`):

- **OGG/Opus- und MP3-Export** für TTS-Ausgabe
- **Atomische Tempfile-Pipeline** (`os.replace`) — kein Teil-/Korrupt-File bei Abbruch
- **Gehärtete Status-Timer-Guards** + **Tempfile-/WAV-Jobdir-Cleanup** aus Follow-up (`a5933f3`)

### Checks (lokal, grün)

- `python3 -m compileall app tests` → OK
- `pytest` (offscreen, GUI-Tests aktiv) → **296 passed**
- `git diff --check` → keine Whitespace-Fehler
- Secret-Scan (CI-Patterns) → 0 echte Treffer (nur Patterns-Datei selbst, die CI explizit excludet)

### Rollback

- `git revert <bump-commit>` (Version zurück auf 0.4.0)
- ggf. zusätzlich `git revert 2c72c308b3bbdaa0882cbcadea8e62ad0d76ac89` (Audio-Export rückgängig)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011t3TuuDrh5TuhcmSHqeUq2