### PR TITLE
docs: remove stale screenshot embeds from READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,6 +1,4 @@
 <div align="center">
-  <img src="docs/screenshots/linux/Banner.png" alt="Blitztext Linux Banner" width="860">
-  
   <h1>Blitztext Linux</h1>
   <p><strong>Dein lokaler KI-Sprachassistent für KDE Plasma & Wayland</strong></p>
 
@@ -150,12 +148,7 @@ Blitztext registriert globale Hotkeys via `evdev`. Mit diesen Kombinationen hast
 
 ## KI-Workflows
 
-Die KI-Workflows helfen bei Formulierung, Ton und Emojis. Die passenden Einstellungen findest du direkt in der App:
-
-<div align="center">
-  <img src="docs/screenshots/linux/settings-ki-workflows.png" alt="KI-Workflows Einstellungen" width="480">
-  <br><br>
-</div>
+Die KI-Workflows helfen bei Formulierung, Ton und Emojis. Die passenden Einstellungen findest du direkt in der App.
 
 ### Schreibstil-Vorlagen
 
@@ -216,12 +209,6 @@ Das Mikrofon im System-Tray ist dein Indikator für den aktuellen Zustand:
 
 Falls du keine Tastatur parat hast oder Hotkeys blockiert sind:
 
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/main-window-compact-glass.png" alt="Hauptfenster" width="480">
-  <br><br>
-</div>
-
 - **Maus-Steuerung:** Start/Stopp-Button für die Aufnahme.
 - **Workflow-Menü:** Dropdown für alle 5 Modi.
 - **Abbruch:** Verwirft eine Aufnahme sofort ohne Transkription.
@@ -234,13 +221,6 @@ Falls du keine Tastatur parat hast oder Hotkeys blockiert sind:
 ## Diktat, Verlauf und Vorlesen
 
 Zusätzlich zu den Workflows bietet das Tool drei Komfort-Funktionen:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/history.png" alt="Verlauf" width="340">
-  <img src="docs/screenshots/linux/tts.png" alt="Vorlesen" width="340">
-  <br><br>
-</div>
 
 | Menüpunkt | Beschreibung |
 | :--- | :--- |
@@ -267,11 +247,6 @@ Zusätzlich zu den Workflows bietet das Tool drei Komfort-Funktionen:
 ## Konfiguration
 
 Alles wird lokal und sicher unter `~/.config/blitztext-linux/config.json` gespeichert. Der OpenAI-Schlüssel wird nicht mehr in dieser Datei abgelegt, sondern aus einer Umgebungsvariable gelesen. Die Konfigurationsdatei lässt sich für erweiterte Prompt- und Workflow-Anpassungen direkt aus den Einstellungen öffnen: **Einstellungen → Allgemein → „Konfigurationsdatei öffnen"**.
-
-<div align="center">
-  <img src="docs/screenshots/linux/settings-allgemein.png" alt="Einstellungen Allgemein" width="480">
-  <br><br>
-</div>
 
 > [!IMPORTANT]
 > Die Konfigurationsdatei wird automatisch mit restriktiven Dateiberechtigungen (**`0o600` / `chmod 600`**) gespeichert. Der echte OpenAI-Key liegt stattdessen in `~/.config/blitztext-linux/secrets.env` oder wird als Umgebungsvariable bereitgestellt.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 <div align="center">
-  <img src="docs/screenshots/linux/Banner.png" alt="Blitztext Linux Banner" width="860">
-  
   <h1>Blitztext Linux</h1>
   <p><strong>Your local AI voice assistant for KDE Plasma & Wayland</strong></p>
 
@@ -150,12 +148,7 @@ Blitztext registers global hotkeys via `evdev`. With these combinations you have
 
 ## AI workflows
 
-The AI workflows help with phrasing, tone, and emojis. You'll find the relevant settings directly in the app:
-
-<div align="center">
-  <img src="docs/screenshots/linux/settings-ki-workflows.png" alt="AI workflow settings" width="480">
-  <br><br>
-</div>
+The AI workflows help with phrasing, tone, and emojis. You'll find the relevant settings directly in the app.
 
 ### Writing-style presets
 
@@ -216,12 +209,6 @@ The microphone in the system tray is your indicator of the current state:
 
 In case you don't have a keyboard handy or hotkeys are blocked:
 
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/main-window-compact-glass.png" alt="Main window" width="480">
-  <br><br>
-</div>
-
 - **Mouse control:** Start/stop button for recording.
 - **Workflow menu:** Dropdown for all 5 modes.
 - **Cancel:** Discards a recording immediately without transcription.
@@ -234,13 +221,6 @@ In case you don't have a keyboard handy or hotkeys are blocked:
 ## Dictation, history, and read-aloud
 
 In addition to the workflows, the tool offers three convenience functions:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/history.png" alt="History" width="340">
-  <img src="docs/screenshots/linux/tts.png" alt="Read aloud" width="340">
-  <br><br>
-</div>
 
 | Menu item | Description |
 | :--- | :--- |
@@ -267,11 +247,6 @@ In addition to the workflows, the tool offers three convenience functions:
 ## Configuration
 
 Everything is stored locally and securely under `~/.config/blitztext-linux/config.json`. The OpenAI key is no longer stored in this file but read from an environment variable. The configuration file can be opened directly from the settings for advanced prompt and workflow adjustments: **Settings → General → "Open configuration file"**.
-
-<div align="center">
-  <img src="docs/screenshots/linux/settings-allgemein.png" alt="General settings" width="480">
-  <br><br>
-</div>
 
 > [!IMPORTANT]
 > The configuration file is automatically saved with restrictive file permissions (**`0o600` / `chmod 600`**). The real OpenAI key instead lives in `~/.config/blitztext-linux/secrets.env` or is provided as an environment variable.


### PR DESCRIPTION
## Zusammenfassung

Enger Doku-Cleanup: entfernt veraltete/deutsche Bildverweise aus `README.md` und `README.de.md`, bevor Banner + Screenshots auf EN-UI/v0.5.0 neu erstellt werden.

Entfernte Embeds (je in beiden READMEs):
- `Banner.png`
- `settings-ki-workflows.png`
- `main-window-compact-glass.png`
- `history.png`
- `tts.png`
- `settings-allgemein.png`

**Beibehalten:** Tray-Status-PNGs (`tray-idle/recording/processing/error.png`).
**Unverändert:** alle Bilddateien bleiben getrackt im Repo (nur die Embeds wurden entfernt). `scripts/_make_screenshots.py` ist **nicht** Teil dieses PR (separater, out-of-scope WIP).

## Kontext

Die alten Screenshots stammen vom 16.06 (vor Paket F/G) und der Banner ist deutsch + zeigt veraltete UI. Dieser PR bereinigt nur die Verweise; die eigentliche Banner-/Screenshot-Neuerstellung (EN-UI/Dark-Mode) bleibt als Roadmap-Item **offen** (Project #10).

## Test plan

- [x] `git diff --check` sauber (keine Whitespace-Fehler)
- [x] `rg` der entfernten Dateinamen über README.md/README.de.md → keine Treffer mehr
- [x] Banner.png + übrige Bilddateien weiterhin getrackt (`git ls-files`)
- [ ] README-Rendering auf GitHub gegenprüfen (Tray-PNGs erscheinen weiterhin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)