### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """BlitztextLinux app package."""
 
 # Single source of truth for the application version.
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Summary

- Bumps `app/__init__.py` version from `0.6.0` → `0.7.0`
- Bundles **Paket J** (Prompt-Transparenz & Prompt-Editor, PR #29)

## Changelog

### Paket J — Prompt-Transparenz & Prompt-Editor
- Show Prompt button in Compose Window (enabled when text is entered)
- Prompt preview/editor dialog showing system prompt + user message before LLM submission
- Full i18n support (DE/EN)

### Fixes
- Secret hygiene scan: removed literal `OPENAI_API_KEY=` from README examples (PR #29 fix)

## Test plan
- [x] CI: Secret hygiene scan ✅
- [x] CI: Tests Python 3.11 ✅
- [x] CI: Tests Python 3.12 ✅
- [x] GitGuardian ✅