### PR TITLE
chore: bump version to 0.8.0

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """BlitztextLinux app package."""
 
 # Single source of truth for the application version.
-__version__ = "0.7.0"
+__version__ = "0.8.0"


### PR DESCRIPTION
Version bump 0.7.0 → 0.8.0.

Bündelt seit v0.7.0:
- PR #31 — Paket K: Schreibstil-Preset-Combo im Hauptfenster + bidirektionale Sync Tray ↔ Hauptfenster