### PR TITLE
test: extend launch smoke coverage for secondary windows

### DIFF
--- a/tests/test_smoke_launch.py
+++ b/tests/test_smoke_launch.py
@@ -89,6 +89,46 @@ def test_app_boots_idles_and_exits_clean(ui_language, tmp_path):
 
 
 @gui_only
+def test_secondary_windows_instantiate(tmp_path):
+    """Settings-, TTS- und History-Fenster lassen sich offscreen instanziieren."""
+    from PyQt6.QtWidgets import QApplication
+
+    from app.blitztext_linux import BlitztextApp, SettingsDialog
+    from app.config import Config
+
+    config = Config.load(tmp_path / "config.json")
+
+    qapp = QApplication.instance() or QApplication([])
+    app = None
+    try:
+        with patch("app.blitztext_linux.Config.load", return_value=config):
+            app = BlitztextApp(qapp)
+        app.stop_hotkey_worker()
+        qapp.processEvents()
+
+        # History-Panel: lazy-init via show_history_panel().
+        app.show_history_panel()
+        qapp.processEvents()
+        assert app._history_panel is not None
+
+        # TTS-Fenster: lazy-init via show_tts_window().
+        app.show_tts_window()
+        qapp.processEvents()
+        assert app._tts_window is not None
+
+        # Settings-Dialog: direkt instanziieren, da show_settings_dialog() exec() aufruft.
+        dlg = SettingsDialog(config)
+        qapp.processEvents()
+        assert dlg is not None
+        dlg.close()
+
+    finally:
+        if app is not None:
+            app.stop_hotkey_worker()
+        set_language(DEFAULT_LANGUAGE)
+
+
+@gui_only
 def test_compose_dialog_lifecycle(tmp_path):
     """Compose-Dialog öffnet sich, wird wiederverwendet und übersetzt sich neu."""
     from PyQt6.QtWidgets import QApplication


### PR DESCRIPTION
## Summary

- Adds `test_secondary_windows_instantiate` to `tests/test_smoke_launch.py`
- Smoke-tests three previously uncovered dialog/panel constructors under `QT_QPA_PLATFORM=offscreen WHISPER_GUI_TESTS=1`:
  - `HistoryPanel` via `app.show_history_panel()` (lazy-init path, same as production)
  - `TtsWindow` via `app.show_tts_window()` (lazy-init path)
  - `SettingsDialog(config)` directly — `show_settings_dialog()` calls `exec()` which would block; direct instantiation is the correct offscreen strategy
- Completes the smoke-coverage goal: MainWindow, Tray, Compose, Settings, TTS, and History are now all exercised

## No runtime side effects

- Config isolated via `tmp_path` fixture; real user config never read
- `stop_hotkey_worker()` called before any window is shown; no real evdev thread
- No audio, no OpenAI/Whisper/Piper calls, no xclip/paste
- No `XDG_RUNTIME_DIR` manipulation
- `try/finally` resets language state to prevent bleed into subsequent tests

## Test plan

- [x] `QT_QPA_PLATFORM=offscreen WHISPER_GUI_TESTS=1 python -m pytest tests/test_smoke_launch.py -v` → 4 passed
- [x] Full suite `python -m pytest -q` → 395 passed
- [x] `python3 -m compileall app tests` → OK
- [x] `git diff --check` → no whitespace errors
- [x] Secret scan → clean (no keys, tokens, credentials)
- [x] Code-reviewer agent → APPROVED, no blocking issues