### PR TITLE
test: cover hotkey error slot handling

### DIFF
--- a/tests/test_hotkey_error_classification.py
+++ b/tests/test_hotkey_error_classification.py
@@ -1,4 +1,6 @@
-from app.blitztext_linux import _is_hotkey_device_access_error
+from unittest.mock import MagicMock, call
+
+from app.blitztext_linux import BlitztextApp, _is_hotkey_device_access_error
 
 
 def test_hotkey_device_access_error_detects_missing_keyboard():
@@ -15,3 +17,28 @@ def test_hotkey_device_access_error_detects_evdev_dependency():
 
 def test_hotkey_device_access_error_ignores_unrelated_errors():
     assert not _is_hotkey_device_access_error("Audioaufnahme konnte nicht gestartet werden")
+
+
+# ---------------------------------------------------------------------------
+# _on_hotkey_error Slot
+# ---------------------------------------------------------------------------
+
+def test_on_hotkey_error_device_access_calls_tray_warning():
+    """Device-Access-Fehler → show_tray_warning, kein show_tray_error."""
+    self = MagicMock()
+    err = "Keine Tastatur-Geraete gefunden"
+    BlitztextApp._on_hotkey_error(self, err)
+    self.show_tray_warning.assert_called_once_with(
+        "Hotkey Hinweis",
+        f"{err}\nStart/Stopp läuft über Fenster/Tray.",
+    )
+    self.show_tray_error.assert_not_called()
+
+
+def test_on_hotkey_error_generic_error_calls_tray_error():
+    """Nicht klassifizierter Fehler → show_tray_error, kein show_tray_warning."""
+    self = MagicMock()
+    err = "Audioaufnahme konnte nicht gestartet werden"
+    BlitztextApp._on_hotkey_error(self, err)
+    self.show_tray_error.assert_called_once_with("Hotkey Fehler", err)
+    self.show_tray_warning.assert_not_called()


### PR DESCRIPTION
Adds focused unit coverage for the `_on_hotkey_error` slot. The tests verify that device-access errors route to `show_tray_warning` and generic hotkey errors route to `show_tray_error`. This is test-only, touches no production code, and does not overlap with the already-merged smoke-test series.