### PR TITLE
fix(installer): warn before daemon-reload when app is running

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -280,6 +280,10 @@ sed "s|%BLITZTEXT_DIR%|${BLITZTEXT_DIR}|g" "${SERVICE_SRC}" > "${SERVICE_DST}"
 done_add "blitztext-linux.service installiert nach ${SERVICE_DST}"
 ok "Service-Datei installiert."
 
+if systemctl --user is-active --quiet blitztext-linux 2>/dev/null; then
+    warn "blitztext-linux läuft gerade. daemon-reload kann die App unerwartet beenden."
+    warn "Empfehlung: App vorher stoppen:  systemctl --user stop blitztext-linux"
+fi
 systemctl --user daemon-reload
 
 if systemctl --user is-enabled --quiet blitztext-linux 2>/dev/null; then


### PR DESCRIPTION
## Ausgangsbefund

Beim Realtest des Installers im Modus B (`BLITZTEXT_NO_HOTKEY=1`) auf dem gummi-Workstation hat `scripts/install.sh` den Befehl `systemctl --user daemon-reload` ausgeführt, während `blitztext-linux` aktiv lief. Die App wurde daraufhin sauber beendet (exit 0, SIGTERM über `PartOf=graphical-session.target`). Kein Datenverlust, aber das Verhalten war unerwartet und ohne Hinweis für den Nutzer.

## Änderung

**Datei:** `scripts/install.sh`

Vor `systemctl --user daemon-reload` wird geprüft, ob der systemd-User-Service `blitztext-linux` gerade aktiv ist. Wenn ja, erscheinen zwei sichtbare `[WARN]`-Zeilen:

```
[WARN]  blitztext-linux läuft gerade. daemon-reload kann die App unerwartet beenden.
[WARN]  Empfehlung: App vorher stoppen:  systemctl --user stop blitztext-linux
```

Der `daemon-reload` wird danach **trotzdem ausgeführt** — kein Auto-Stop, kein Auto-Restart, keine blockierende Abfrage. Der Nutzer entscheidet selbst.

Wenn der Service nicht läuft oder keine systemd-User-Sitzung verfügbar ist, läuft der Installer wie bisher unverändert weiter (`2>/dev/null` schluckt alle Fehler).

## Tests / Checks

| Check | Ergebnis |
|---|---|
| `bash -n scripts/install.sh` | OK |
| `python3 -m compileall app tests` | OK |
| `QT_QPA_PLATFORM=offscreen WHISPER_GUI_TESTS=1 python -m pytest -q` | 397 passed |
| `git diff --check` | OK |
| Secret-Scan | sauber |

## Restrisiko

Die Prüfung erkennt nur Instanzen, die über den systemd-User-Service `blitztext-linux` laufen. Eine manuell gestartete App via `./run.sh` oder direktem `python -m blitztext_linux` wird **nicht erkannt** und erhält keine Warnung. Dieses Verhalten ist dokumentiert und akzeptiert.

## Rollback

```bash
git revert f4ad65d
```