### PR TITLE
release: v0.8.1

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -470,3 +470,9 @@ Das Original-Projekt ist ein experimentelles, nicht-kommerzielles Open-Source-Pr
 <div align="center">
   <sub>Erstellt mit ❤️ (und ein bisschen KI-Hilfe).</sub>
 </div>
+
+### v0.8.1: Absichtstreue Prompts und bessere Diagnose
+
+Blitztext+ und die Schreibstil-Presets bewahren die Absicht der Eingabe jetzt konservativer. Sie sollen bei diktierten Arbeitsanweisungen oder Übergabe-Prompts keine Meetings, Teilnehmer, Empfänger, Rollen oder Ziele erfinden. E-Mail-Presets nutzen eine E-Mail-artige Struktur nur dann, wenn die Eingabe erkennbar als Nachricht an jemanden gemeint ist.
+
+Das Linux-Prüfskript enthält außerdem verbesserte sitzungsabhängige Desktop-Diagnosen für X11, Wayland und Clipboard-Backends. Die Kompatibilitätsmatrix ist Diagnosehilfe, kein Supportversprechen.

--- a/README.md
+++ b/README.md
@@ -474,3 +474,9 @@ The original project is an experimental, non-commercial open-source project unde
 <div align="center">
   <sub>Made with ❤️ (and a little AI help).</sub>
 </div>
+
+### v0.8.1: Intent-preserving prompts and diagnostics
+
+Blitztext+ and the writing presets now preserve the user's intent more conservatively. They avoid inventing meetings, participants, recipients, roles, or goals when rewriting spoken work instructions or handover prompts. Email presets only use email-like structure when the input is clearly meant as a message to someone.
+
+The Linux verification script also includes improved session-aware desktop diagnostics for X11, Wayland, and clipboard backends. The compatibility matrix is diagnostic guidance, not a support promise.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
 """BlitztextLinux app package."""
 
 # Single source of truth for the application version.
-__version__ = "0.8.0"
+__version__ = "0.8.1"


### PR DESCRIPTION
## Summary
- bump app version to v0.8.1
- document improved Blitztext+ and writing preset intent preservation
- document improved session-aware Linux desktop diagnostics

## Verification
- python3 -m compileall app tests
- QT_QPA_PLATFORM=offscreen WHISPER_GUI_TESTS=1 python -m pytest -q
- git diff --check
- bash -n scripts/verify.sh
- bash -n scripts/install.sh
- git ls-files ROADMAP.md

## Notes
- no feature expansion
- no ROADMAP.md
- no tag or GitHub release yet
- tag/release only after this PR is merged