### PR TITLE
spike(flatpak): add MVP manifest scaffold

### DIFF
--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -1,0 +1,82 @@
+# Flatpak-MVP-Spike (packaging/flatpak/)
+
+Minimaler, lokal getesteter Ansatz, um BlitztextLinux als GUI-App in einer
+Flatpak-Sandbox zu starten. Kein Release-, Flathub- oder Signing-Setup.
+
+## Umfang (MVP)
+
+Absichtlich enthalten:
+- Qt6-GUI (`org.kde.Platform`/`org.kde.Sdk` 6.8)
+- Zwischenablage ueber den bestehenden Qt-Clipboard-Fallback
+  (`app/paste_service.py`, bereits in PR #47 gehaertet)
+- Audioaufnahme ueber PulseAudio-Socket
+- Cloud-Aufrufe (OpenAI: LLM-Workflows, ggf. Transkription/TTS) ueber
+  `--share=network`
+
+Absichtlich **nicht** enthalten / sichtbar deaktiviert:
+- Globale Hotkeys (evdev) -- `app/hotkey_service.py` importiert `evdev` lazy
+  und liefert im Flatpak bereits den Hinweis
+  "Globale Hotkeys sind im Flatpak nicht verfügbar"
+  (siehe `tests/test_flatpak_fallback.py::test_hotkey_service_flatpak_hint`).
+  Der Sandbox fehlt bewusst jeder Input-Device-Zugriff
+  (kein `--device=all`, kein `input`-Gruppen-Aequivalent).
+- Auto-Paste via `ydotool` (kein Provider im Sandbox vorgesehen; Clipboard-
+  Kopie funktioniert weiter, siehe bestehender Fallback-Test
+  `test_paste_service_autopaste_without_ydotool`).
+- Lokale Whisper-Transkription (`openai-whisper`/`faster-whisper`/`torch`):
+  bewusst aus `requirements-flatpak.txt` ausgeklammert, da der Download
+  mehrere GB umfasst. `app/transcribe.py` importiert `whisper` ebenfalls
+  lazy, das Modul ist fuer eine spaetere Erweiterung vorbereitet.
+- Desktop-Notifications (`notify-send` ist im Sandbox nicht gebuendelt;
+  `app/notify.py` degradiert bereits stillschweigend, wenn das Binary fehlt).
+
+## Dateien
+
+- `io.github.TimInTech.BlitztextLinux.yaml` -- Flatpak-Manifest.
+  `io.github.TimInTech.*` ist ein Platzhalter-App-ID-Namespace (an das
+  GitHub-Repo `TimInTech/blitztext-linux` angelehnt), nicht auf Flathub
+  registriert.
+- `blitztext-linux.sh` -- Launcher, ruft `app/blitztext_linux.py` direkt auf.
+- `requirements-flatpak.txt` -- reduzierte pip-Abhaengigkeiten fuer den
+  Sandbox-Build (nur `PyQt6` + `openai`).
+
+## Bekannte Abweichungen von Flathub-Konventionen
+
+- Das `blitztext-linux-deps`-Modul installiert pip-Pakete direkt aus PyPI
+  waehrend des Builds (`--share=network` nur fuer dieses Modul). Flathub
+  verlangt gepinnte/vendored Quellen (z. B. via `flatpak-pip-generator`).
+  Fuer diesen lokalen MVP-Spike bewusst nicht umgesetzt.
+- Kein AppStream-Metadata-File, kein `.desktop`-File, kein Icon --
+  ausserhalb dieses Ordners wurden bewusst keine Dateien angelegt.
+- `notes_folder`-Export (`~/Blitztext-Notizen`, siehe `app/config.py`)
+  liegt ausserhalb des sandboxed `$HOME`; ohne zusaetzliches
+  `--filesystem=home` bleibt dieser Pfad im Flatpak unerreichbar. Nicht
+  Teil des MVP-Scopes, hier nur dokumentiert.
+
+## Verifikation (in diesem Spike durchgefuehrt)
+
+`flatpak-builder` 1.4.8 ist auf diesem Host vorhanden. Ein vollstaendiger
+Build (Download von `org.kde.Platform`/`org.kde.Sdk` 6.8, ca. 1,5 GB) wurde
+in diesem Diagnose-Pass **nicht** ausgefuehrt -- das waere ein groesserer,
+bestaetigungspflichtiger Download/Installationsschritt ausserhalb des
+Spike-Rahmens. Stattdessen nur strukturelle Validierung ohne Runtime-Install:
+
+```bash
+flatpak-builder --show-manifest packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
+flatpak-builder --show-deps packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
+```
+
+## Naechster Schritt (nicht Teil dieses Spikes)
+
+Falls ein echter Build gewuenscht ist:
+
+```bash
+flatpak install flathub org.kde.Platform//6.8 org.kde.Sdk//6.8
+flatpak-builder --user --install --force-clean build-dir \
+  packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
+flatpak run io.github.TimInTech.BlitztextLinux
+```
+
+Rollback: `packaging/flatpak/` einfach loeschen bzw. den Branch
+`spike/flatpak-manifest-mvp` verwerfen -- keine Aenderungen ausserhalb
+dieses Ordners.

--- a/packaging/flatpak/blitztext-linux.sh
+++ b/packaging/flatpak/blitztext-linux.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Flatpak-Launcher fuer BlitztextLinux (MVP-Spike).
+#
+# app/blitztext_linux.py fuegt sein Projektverzeichnis (der Elternordner von
+# app/) beim Start selbst zu sys.path hinzu (siehe PROJECT_DIR-Logik am
+# Dateianfang), daher genuegt ein direkter Aufruf ueber den vollen Pfad.
+exec python3 /app/share/blitztext-linux/app/blitztext_linux.py "$@"

--- a/packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
+++ b/packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
@@ -1,0 +1,46 @@
+app-id: io.github.TimInTech.BlitztextLinux
+runtime: org.kde.Platform
+runtime-version: "6.8"
+sdk: org.kde.Sdk
+command: blitztext-linux
+
+# MVP-Sandbox-Rechte: nur was fuer GUI, Zwischenablage (Qt-Fallback),
+# Audioaufnahme (PulseAudio) und Cloud-Aufrufe (OpenAI) noetig ist.
+# Bewusst NICHT enthalten: --device=all / --system-talk-name=... fuer
+# evdev-Zugriff -- globale Hotkeys bleiben im Flatpak deaktiviert
+# (app/hotkey_service.py faengt das fehlende evdev bereits ab, siehe
+# tests/test_flatpak_fallback.py::test_hotkey_service_flatpak_hint).
+finish-args:
+  - --share=ipc
+  - --share=network
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+
+modules:
+  - name: blitztext-linux-deps
+    buildsystem: simple
+    # Netzwerk nur fuer dieses Modul erlauben (pip-Installation).
+    # Nicht Flathub-konform (keine gepinnten/vendored Quellen) -- fuer
+    # diesen MVP-Spike bewusst so belassen, siehe README.md.
+    build-options:
+      build-args:
+        - --share=network
+    build-commands:
+      - pip3 install --prefix=/app --no-build-isolation -r requirements-flatpak.txt
+    sources:
+      - type: file
+        path: requirements-flatpak.txt
+
+  - name: blitztext-linux
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 blitztext-linux.sh /app/bin/blitztext-linux
+      - mkdir -p /app/share/blitztext-linux
+      - cp -r app /app/share/blitztext-linux/app
+    sources:
+      - type: dir
+        path: ../../app
+        dest: app
+      - type: file
+        path: blitztext-linux.sh

--- a/packaging/flatpak/requirements-flatpak.txt
+++ b/packaging/flatpak/requirements-flatpak.txt
@@ -1,0 +1,15 @@
+# Laufzeit-Abhaengigkeiten fuer den Flatpak-MVP-Spike.
+#
+# Bewusst NICHT enthalten (siehe README.md fuer Details):
+#   - evdev              -> globale Hotkeys sind im Flatpak-MVP deaktiviert;
+#                            app/hotkey_service.py importiert evdev lazy und
+#                            faengt das Fehlen bereits ab.
+#   - openai-whisper /
+#     faster-whisper /
+#     torch             -> lokale Transkription ist im MVP-Spike nicht
+#                            Teil des Build-Checks (mehrere GB Download).
+#                            app/transcribe.py importiert whisper ebenfalls
+#                            lazy; das Modul bleibt fuer eine spaetere
+#                            Erweiterung vorbereitet.
+PyQt6
+openai


### PR DESCRIPTION
## Ziel

Dieser PR ergänzt einen experimentellen Flatpak-MVP-Scaffold für Blitztext Linux im bestehenden Repository. Ziel ist nur ein lokaler Packaging-Spike, kein Release- oder Flathub-Setup.

## Scope

Enthalten:

- `packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml`
- `packaging/flatpak/blitztext-linux.sh`
- `packaging/flatpak/requirements-flatpak.txt`
- `packaging/flatpak/README.md`

Der MVP fokussiert:

- GUI-Start innerhalb einer Flatpak-Sandbox
- Qt-Clipboard-Fallback
- PulseAudio-Aufnahme
- OpenAI-Cloud-Aufrufe

Bewusst nicht enthalten:

- globale Hotkeys über evdev/input
- ydotool-Auto-Paste
- lokale Whisper/Torch-Transkription im Flatpak-Build
- Desktop-Datei, AppStream, Icon oder Flathub-Einreichung
- Release, Tag oder Version-Bump

## Grenzen

Das Manifest ist für lokale MVP-Tests gedacht und noch nicht Flathub-konform. Insbesondere sind pip-/Netzwerkabhängigkeiten und vendored Sources noch nicht final gelöst.

Ein vollständiger Build wurde bewusst nicht ausgeführt, weil dafür größere Runtime-/Build-Downloads nötig wären.

## Verifikation

Lokal grün:

- `python3 -m compileall app tests`
- `QT_QPA_PLATFORM=offscreen WHISPER_GUI_TESTS=1 python -m pytest -q`
- `bash -n scripts/install.sh`
- `bash -n scripts/verify.sh`
- `git diff --check`
- Secret-Scan negativ
- `flatpak-builder --show-manifest` OK
- `flatpak-builder --show-deps` OK

## Rollback

Vor Merge: Branch/PR schließen und Branch löschen.

Nach Merge: Squash-Commit per `git revert <squash-commit>` zurücknehmen.
