### PR TITLE
fix(flatpak): enable tray registration and harden documentation

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -18,6 +18,12 @@
 
 ---
 
+## Zweck
+
+Blitztext Linux ist ein Hotkey-gesteuerter Sprachassistent, der gesprochene Sprache in Text umwandelt und direkt in die gerade aktive Anwendung einfügt. Die Transkription läuft standardmäßig lokal über Whisper; ein LLM-Schritt ist optional und wird nur genutzt, wenn du bewusst einen der KI-Workflows (Umformulierung, Ton-Filter, Emoji-Anreicherung) oder das Compose-Fenster auswählst. Alles bleibt auf deinem Rechner, solange du nicht bewusst einen Cloud-Anbieter (OpenAI, OpenRouter oder einen eigenen OpenAI-kompatiblen Endpunkt) für LLM- oder Cloud-TTS-Funktionen aktivierst.
+
+---
+
 ## Features
 
 - **Mehrsprachige Oberfläche (EN/DE):** Schalte die App-Oberfläche zwischen Deutsch und Englisch um – unter **Einstellungen → Allgemein → „Sprache der Oberfläche"** (die Änderung greift nach einem Neustart der App).
@@ -30,9 +36,180 @@
 - **LLM-gestützte Workflows:** Lass die KI deine Sätze professionell umformulieren, emotional filtern oder mit passenden Emojis anreichern.
 - **Lokale Verarbeitung:** Optional 100% offline für volle Privatsphäre.
 
+### Die 5 Workflows und Hotkeys
+
+Blitztext registriert globale Hotkeys via `evdev`. Mit diesen Kombinationen hast du die volle Kontrolle:
+
+| Workflow | Hotkey | LLM? | Beschreibung |
+| :--- | :--- | :---: | :--- |
+| **Blitztext** | <kbd>Meta</kbd> + <kbd>H</kbd> | ❌ | Standard: Nimmt auf, transkribiert und fügt den Text ein. |
+| **Blitztext Lokal** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd> | ❌ | Erzwingt eine reine **Offline-Transkription**. |
+| **Blitztext+** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>T</kbd> | ✅ | Formuliert deine Aufnahme professionell via LLM um. |
+| **Blitztext $%&!** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> | ✅ | Emotionale Entladung: Wandelt Frust in eine sachliche Nachricht um. |
+| **Blitztext :)** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd> | ✅ | Ergänzt deine Nachricht passend mit Emojis. |
+
+> [!NOTE]
+> **LLM-Workflows** (`Blitztext+`, `Blitztext $%&!`, `Blitztext :)`) setzen einen gültigen **API-Key** voraus. Siehe [Secrets](#secrets) weiter unten für die Konfiguration. Ohne diesen Key sind diese Funktionen im Menü und über die Hotkeys deaktiviert bzw. führen zu einer Fehlermeldung.
+
+### KI-Workflows
+
+Die KI-Workflows helfen bei Formulierung, Ton und Emojis. Die passenden Einstellungen findest du unter **Einstellungen → KI-Workflows**:
+
+<div align="center">
+  <img src="docs/screenshots/linux/settings-ai-workflows-en.png" alt="KI-Workflow-Einstellungen" width="480">
+  <br><br>
+</div>
+
+**LLM-Anbieter.** Blitztext unterstützt drei Anbieter-Modi, wählbar unter **Einstellungen → KI-Workflows → „LLM-Anbieter"**:
+
+| Anbieter | Wann verwenden |
+| :--- | :--- |
+| **OpenAI** (Standard) | Standard-OpenAI-API mit `gpt-4o-mini` oder einem anderen Modell. |
+| **OpenRouter** | Zugriff auf hunderte Modelle über einen einzigen API-Key (`OPENROUTER_API_KEY`). Base-URL: `https://openrouter.ai/api/v1`. |
+| **Eigener Endpunkt** | Jede OpenAI-kompatible API — „Base-URL" und „LLM-Modell" auf den Anbieter anpassen. |
+
+Für OpenRouter `base_url` auf `https://openrouter.ai/api/v1` setzen und Modell wählen (z. B. `openai/gpt-4o`). Der Name der API-Key-Umgebungsvariable wird unter „API-Key-Umgebung" eingestellt.
+
+**Schreibstil-Vorlagen.** Für den Workflow **Blitztext+** (Text-Verbesserer) gibt es vorgefertigte Schreibstil-Vorlagen, die du unter **Einstellungen → KI-Workflows → „Schreibstil-Vorlage"** oder direkt im **Compose-Fenster** auswählst:
+
+| Vorlage | Wirkung |
+| --- | --- |
+| **Standard (Text verbessern)** | Bisheriges Verhalten – sauber formatierter Text, der gewählte **Tonfall** greift. |
+| **E-Mail – formell** | Höfliche E-Mail in der Sie-Form mit klarer Struktur. |
+| **E-Mail – locker** | Freundliche E-Mail in der Du-Form. |
+| **Stichpunkte** | Gliedert den Inhalt in prägnante Stichpunkte. |
+| **Zusammenfassung** | Knappe, sachliche Zusammenfassung der Kernaussagen. |
+| **Persönlich (Du-Form)** | Klarer Text in der persönlichen Du-Form. |
+| **Höflich (Sie-Form)** | Klarer Text in der höflichen Sie-Form. |
+| **Kurz & präzise** | Maximal knapp, ohne Füllwörter und Wiederholungen. |
+| **Eigenes Preset…** | Ein freier System-Prompt, den du selbst unter **Einstellungen → Allgemein → „Eigenes Preset (Compose)"** festlegst. |
+
+> Bei **Standard** wird zusätzlich der eingestellte **Tonfall** angewendet. Jede andere Vorlage bringt ihren eigenen Schreibstil mit und überschreibt den Tonfall. Eigennamen/Begriffe bleiben in allen Vorlagen erhalten.
+
+### Compose-Fenster
+
+Das **Compose-Fenster** (`✍ Compose…` im Tray-Kontextmenü) ermöglicht das Umschreiben beliebiger Texte mit der KI — ganz ohne Sprachaufnahme. Es eignet sich ideal zum Überarbeiten fertiger Entwürfe, E-Mails oder Notizen.
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/compose-en.png" alt="Compose-Fenster" width="480">
+  <br><br>
+</div>
+
+**Öffnen:** Klick auf das Tray-Icon → **✍ Compose…**
+
+**Was du im Compose-Fenster tun kannst:**
+
+| Element | Beschreibung |
+| :--- | :--- |
+| **Entwurf (linkes Feld)** | Text eintippen oder einfügen, der umgeschrieben werden soll. |
+| **Workflow** | Wähle zwischen Blitztext+ (Text-Verbesserer), Blitztext $%&! (Dampfablassen) oder Blitztext :) (Emojis). |
+| **Schreibstil-Vorlage** | Vorlage auswählen oder **Eigenes Preset…** für einen vollständig freien System-Prompt. |
+| **Tonfall** | Locker, neutral oder professionell. Aktiv nur bei **Standard**-Preset + **Blitztext+**; bei allen anderen Vorlagen ausgegraut (Tooltip erklärt warum). |
+| **Verbessern** | Sendet den Entwurf an die KI und zeigt das Ergebnis im rechten Feld. |
+| **Varianten-Verlauf** | Die letzten 10 generierten Ergebnisse der aktuellen Sitzung werden als scrollbare Liste gespeichert — Klick auf einen Eintrag stellt ihn wieder her. |
+| **Signatur** | Hängt deine gespeicherte Signatur an (konfiguriert unter **Einstellungen → Allgemein**). Ersetzt automatisch gängige KI-generierte Platzhalter wie `[Your Name]`, `[Ihr Name]`, `[Vorname Nachname]`, `[Signature]` u. Ä. — kein verlorener Platzhalter bleibt zurück. |
+| **Kopieren** | Kopiert das Ergebnis in die Zwischenablage. |
+| **Einfügen & Schließen** | Fügt das Ergebnis direkt in die aktive Anwendung ein und schließt das Fenster. |
+
+> [!NOTE]
+> Signatur und eigener Preset-Text werden unter **Einstellungen → Allgemein** konfiguriert. Setze dort „Signatur für das Compose-Fenster" und aktiviere „Nach jeder Generierung automatisch anhängen", wenn die Signatur bei jedem Ergebnis ergänzt werden soll.
+
+### Tray-Symbol: Statusfarben
+
+Das Mikrofon im System-Tray ist dein Indikator für den aktuellen Zustand:
+
+<div align="center">
+  <table>
+    <tr>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-idle.png" width="60"><br><br>
+        <b>Grün</b> (IDLE)<br>
+        <i>Bereit — wartet auf deinen Einsatz.</i>
+      </td>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-recording.png" width="60"><br><br>
+        <b>Rot</b> (RECORDING)<br>
+        <i>Aufnahme läuft aktiv.</i>
+      </td>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-processing.png" width="60"><br><br>
+        <b>Orange</b> (TRANSCRIBING)<br>
+        <i>Magie läuft (Transkription / KI-Umformulierung).</i>
+      </td>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-error.png" width="60"><br><br>
+        <b>Grau</b> (ERROR)<br>
+        <i>Ups, etwas ist schiefgelaufen.</i>
+      </td>
+    </tr>
+  </table>
+</div>
+
+Das Tray-Kontextmenü gibt dir schnellen Zugriff auf alle Workflows, das Compose-Fenster, Schreibstil-Vorlagen, Diktat-Modus, Verlauf und Einstellungen:
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/tray-menu-en.png" alt="Tray-Kontextmenü" width="280">
+  <br><br>
+</div>
+
+> [!NOTE]
+> Steht im Desktop-Environment kein Tray-Bereich zur Verfügung, fällt das Icon auf das System-Theme `audio-input-microphone` zurück; die Farbkodierung greift dann ggf. nicht.
+
+### Hauptfenster
+
+Das Hauptfenster ist dein grafisches Kontrollzentrum — nützlich, wenn Hotkeys blockiert sind oder du lieber mit der Maus arbeitest:
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/main-window-en.png" alt="Hauptfenster" width="300">
+  <br><br>
+</div>
+
+- **Workflow-Dropdown:** Alle 5 Aufnahmemodi zur Auswahl.
+- **Schreibstil-Vorlage:** Sichtbar wenn **Blitztext+** gewählt ist — Preset direkt im Hauptfenster wählen. Änderungen werden sofort mit dem Tray synchronisiert.
+- **Start/Stopp-Button:** Klick zum Starten oder Beenden einer Aufnahme.
+- **Abbruch:** Bricht die aktuelle Aufnahme ohne Transkription ab.
+- **Diktat / Verlauf:** Schnellzugriff auf den Diktat-Modus und den Transkript-Verlauf.
+- **Vorlesen / Einstellungen:** Öffnet das Vorlese-Fenster oder den Einstellungs-Dialog.
+
+*Das Fenster öffnet sich beim Start sowie über den Tray-Eintrag **Fenster anzeigen** oder einen Klick auf das Tray-Icon. Schließen versteckt das Fenster nur — die App läuft im Tray weiter.*
+
+### Diktat, Verlauf und Vorlesen
+
+Zusätzlich zu den Workflows bietet das Tool drei Komfort-Funktionen:
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/history-en.png" alt="Verlauf" width="340">
+  <img src="docs/screenshots/linux/tts-en.png" alt="Vorlesen" width="340">
+  <br><br>
+</div>
+
+| Menüpunkt | Beschreibung |
+| :--- | :--- |
+| **Diktat-Modus** | Umschalter. Ist er aktiv, werden alle Transkripte als Diktat-Einträge gesammelt und einzeln als Markdown-Datei gespeichert. Im Verlauf erscheint dann eine Schaltfläche **Zusammenführen**, die alle Einträge kombiniert und in die Zwischenablage kopiert. |
+| **Verlauf…** | Öffnet ein Fenster mit den letzten Transkripten. Pro Eintrag: In Zwischenablage kopieren oder löschen. |
+| **Vorlesen…** | Lässt dir beliebigen Text vorlesen — lokal per **Piper TTS** (Standard) oder optional über **OpenAI Cloud-TTS** (inklusive Anbieter-, Stimmen- und Modellauswahl). Nutze die Schaltfläche **Exportieren**, um die Audioausgabe als Datei zu speichern. |
+
+> [!NOTE]
+> **Diktat-Notizen** werden ausschließlich in einen Ordner **innerhalb des Home-Verzeichnisses** geschrieben (Schutz gegen Pfad-Ausbruch), mit Berechtigungen `0o600`.
+
+> [!IMPORTANT]
+> **Piper TTS** muss für die Vorlesefunktion (sowie Stimmen) installiert sein:
+> ```bash
+> .venv/bin/pip install piper-tts
+> # Stimmen (.onnx + .onnx.json) nach ~/.local/share/piper-voices/ legen
+> ```
+> Fehlt Piper oder eine Stimme, zeigt das Vorlese-Fenster einen Installationshinweis; alle übrigen Funktionen bleiben nutzbar. Optionale Desktop-Benachrichtigungen nutzen `notify-send` (Paket `libnotify-bin`).
+
+> [!NOTE]
+> **OpenAI Cloud-TTS** ist eine optionale Alternative zu Piper. Voraussetzung: das `openai`-Paket (`.venv/bin/pip install openai`) und ein gültiger Key in der Umgebungsvariable `OPENAI_API_KEY` (siehe [Secrets](#secrets) unten). Beim ersten Umschalten auf den Anbieter „OpenAI Cloud" fragt das Vorlese-Fenster einmalig nach Bestätigung, da der eingegebene Text zur Synthese an die OpenAI-Server gesendet wird. Piper bleibt Standard und arbeitet vollständig lokal.
+
 ---
 
-## Installation
+## Installation & Start
 
 ### Schnellinstallation (empfohlen)
 
@@ -112,7 +289,7 @@ pip install PyQt6 evdev openai pytest openai-whisper faster-whisper
 ```
 
 **4. Whisper-Engine als Alternative via pipx**
-Falls Sie `openai-whisper` losgelöst von der venv installieren möchten (umgeht Versionskonflikte auf neueren Ubuntu-Setups durch Python 3.11):
+Falls du `openai-whisper` losgelöst von der venv installieren möchtest (umgeht Versionskonflikte auf neueren Ubuntu-Setups durch Python 3.11):
 ```bash
 pipx install --python "$(command -v python3.11)" openai-whisper
 pipx inject openai-whisper faster-whisper   # optional, für beschleunigte Ausführung
@@ -138,194 +315,9 @@ systemctl --user enable --now ydotool.service   # nutzt /usr/local/bin/ydotoold
 
 ---
 
-## Die 5 Workflows und Hotkeys
-
-Blitztext registriert globale Hotkeys via `evdev`. Mit diesen Kombinationen hast du die volle Kontrolle:
-
-| Workflow | Hotkey | LLM? | Beschreibung |
-| :--- | :--- | :---: | :--- |
-| **Blitztext** | <kbd>Meta</kbd> + <kbd>H</kbd> | ❌ | Standard: Nimmt auf, transkribiert und fügt den Text ein. |
-| **Blitztext Lokal** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd> | ❌ | Erzwingt eine reine **Offline-Transkription**. |
-| **Blitztext+** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>T</kbd> | ✅ | Formuliert deine Aufnahme professionell via LLM um. |
-| **Blitztext $%&!** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> | ✅ | Emotionale Entladung: Wandelt Frust in eine sachliche Nachricht um. |
-| **Blitztext :)** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd> | ✅ | Ergänzt deine Nachricht passend mit Emojis. |
-
-> [!NOTE]
-> **LLM-Workflows** (`Blitztext+`, `Blitztext $%&!`, `Blitztext :)`) setzen einen gültigen **API-Key** voraus. Lege ihn am einfachsten in `~/.config/blitztext-linux/secrets.env` ab, indem du dort die Variable mit deinem Key als Wert setzt (Zeilenformat `NAME=WERT`, z. B. `OPENAI_API_KEY` mit deinem Key als Wert). `./run.sh` und der systemd-Service laden diese Datei automatisch. Ohne diesen Key sind diese Funktionen im Menü und über die Hotkeys deaktiviert bzw. führen zu einer Fehlermeldung.
-
-## KI-Workflows
-
-Die KI-Workflows helfen bei Formulierung, Ton und Emojis. Die passenden Einstellungen findest du unter **Einstellungen → KI-Workflows**:
-
-<div align="center">
-  <img src="docs/screenshots/linux/settings-ai-workflows-en.png" alt="KI-Workflow-Einstellungen" width="480">
-  <br><br>
-</div>
-
-### LLM-Anbieter
-
-Blitztext unterstützt drei Anbieter-Modi, wählbar unter **Einstellungen → KI-Workflows → „LLM-Anbieter"**:
-
-| Anbieter | Wann verwenden |
-| :--- | :--- |
-| **OpenAI** (Standard) | Standard-OpenAI-API mit `gpt-4o-mini` oder einem anderen Modell. |
-| **OpenRouter** | Zugriff auf hunderte Modelle über einen einzigen API-Key (`OPENROUTER_API_KEY`). Base-URL: `https://openrouter.ai/api/v1`. |
-| **Eigener Endpunkt** | Jede OpenAI-kompatible API — „Base-URL" und „LLM-Modell" auf den Anbieter anpassen. |
-
-Für OpenRouter `base_url` auf `https://openrouter.ai/api/v1` setzen und Modell wählen (z. B. `openai/gpt-4o`). Der Name der API-Key-Umgebungsvariable wird unter „API-Key-Umgebung" eingestellt.
-
-### Schreibstil-Vorlagen
-
-Für den Workflow **Blitztext+** (Text-Verbesserer) gibt es vorgefertigte Schreibstil-Vorlagen, die du unter **Einstellungen → KI-Workflows → „Schreibstil-Vorlage"** oder direkt im **Compose-Fenster** auswählst:
-
-| Vorlage | Wirkung |
-| --- | --- |
-| **Standard (Text verbessern)** | Bisheriges Verhalten – sauber formatierter Text, der gewählte **Tonfall** greift. |
-| **E-Mail – formell** | Höfliche E-Mail in der Sie-Form mit klarer Struktur. |
-| **E-Mail – locker** | Freundliche E-Mail in der Du-Form. |
-| **Stichpunkte** | Gliedert den Inhalt in prägnante Stichpunkte. |
-| **Zusammenfassung** | Knappe, sachliche Zusammenfassung der Kernaussagen. |
-| **Persönlich (Du-Form)** | Klarer Text in der persönlichen Du-Form. |
-| **Höflich (Sie-Form)** | Klarer Text in der höflichen Sie-Form. |
-| **Kurz & präzise** | Maximal knapp, ohne Füllwörter und Wiederholungen. |
-| **Eigenes Preset…** | Ein freier System-Prompt, den du selbst unter **Einstellungen → Allgemein → „Eigenes Preset (Compose)"** festlegst. |
-
-> Bei **Standard** wird zusätzlich der eingestellte **Tonfall** angewendet. Jede andere Vorlage bringt ihren eigenen Schreibstil mit und überschreibt den Tonfall. Eigennamen/Begriffe bleiben in allen Vorlagen erhalten.
-
----
-
-## Compose-Fenster
-
-Das **Compose-Fenster** (`✍ Compose…` im Tray-Kontextmenü) ermöglicht das Umschreiben beliebiger Texte mit der KI — ganz ohne Sprachaufnahme. Es eignet sich ideal zum Überarbeiten fertiger Entwürfe, E-Mails oder Notizen.
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/compose-en.png" alt="Compose-Fenster" width="480">
-  <br><br>
-</div>
-
-**Öffnen:** Klick auf das Tray-Icon → **✍ Compose…**
-
-**Was du im Compose-Fenster tun kannst:**
-
-| Element | Beschreibung |
-| :--- | :--- |
-| **Entwurf (linkes Feld)** | Text eintippen oder einfügen, der umgeschrieben werden soll. |
-| **Workflow** | Wähle zwischen Blitztext+ (Text-Verbesserer), Blitztext $%&! (Dampfablassen) oder Blitztext :) (Emojis). |
-| **Schreibstil-Vorlage** | Vorlage auswählen oder **Eigenes Preset…** für einen vollständig freien System-Prompt. |
-| **Tonfall** | Locker, neutral oder professionell. Aktiv nur bei **Standard**-Preset + **Blitztext+**; bei allen anderen Vorlagen ausgegraut (Tooltip erklärt warum). |
-| **Verbessern** | Sendet den Entwurf an die KI und zeigt das Ergebnis im rechten Feld. |
-| **Varianten-Verlauf** | Die letzten 10 generierten Ergebnisse der aktuellen Sitzung werden als scrollbare Liste gespeichert — Klick auf einen Eintrag stellt ihn wieder her. |
-| **Signatur** | Hängt deine gespeicherte Signatur an (konfiguriert unter **Einstellungen → Allgemein**). Ersetzt automatisch gängige KI-generierte Platzhalter wie `[Your Name]`, `[Ihr Name]`, `[Vorname Nachname]`, `[Signature]` u. Ä. — kein verlorener Platzhalter bleibt zurück. |
-| **Kopieren** | Kopiert das Ergebnis in die Zwischenablage. |
-| **Einfügen & Schließen** | Fügt das Ergebnis direkt in die aktive Anwendung ein und schließt das Fenster. |
-
-> [!NOTE]
-> Signatur und eigener Preset-Text werden unter **Einstellungen → Allgemein** konfiguriert. Setze dort „Signatur für das Compose-Fenster" und aktiviere „Nach jeder Generierung automatisch anhängen", wenn die Signatur bei jedem Ergebnis ergänzt werden soll.
-
----
-
-## Tray-Symbol: Statusfarben
-
-Das Mikrofon im System-Tray ist dein Indikator für den aktuellen Zustand:
-
-<div align="center">
-  <table>
-    <tr>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-idle.png" width="60"><br><br>
-        <b>Grün</b> (IDLE)<br>
-        <i>Bereit — wartet auf deinen Einsatz.</i>
-      </td>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-recording.png" width="60"><br><br>
-        <b>Rot</b> (RECORDING)<br>
-        <i>Aufnahme läuft aktiv.</i>
-      </td>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-processing.png" width="60"><br><br>
-        <b>Orange</b> (TRANSCRIBING)<br>
-        <i>Magie läuft (Transkription / KI-Umformulierung).</i>
-      </td>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-error.png" width="60"><br><br>
-        <b>Grau</b> (ERROR)<br>
-        <i>Ups, etwas ist schiefgelaufen.</i>
-      </td>
-    </tr>
-  </table>
-</div>
-
-Das Tray-Kontextmenü gibt dir schnellen Zugriff auf alle Workflows, das Compose-Fenster, Schreibstil-Vorlagen, Diktat-Modus, Verlauf und Einstellungen:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/tray-menu-en.png" alt="Tray-Kontextmenü" width="280">
-  <br><br>
-</div>
-
-> [!NOTE]
-> Steht im Desktop-Environment kein Tray-Bereich zur Verfügung, fällt das Icon auf das System-Theme `audio-input-microphone` zurück; die Farbkodierung greift dann ggf. nicht.
-
----
-
-## Hauptfenster
-
-Das Hauptfenster ist dein grafisches Kontrollzentrum — nützlich, wenn Hotkeys blockiert sind oder du lieber mit der Maus arbeitest:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/main-window-en.png" alt="Hauptfenster" width="300">
-  <br><br>
-</div>
-
-- **Workflow-Dropdown:** Alle 5 Aufnahmemodi zur Auswahl.
-- **Schreibstil-Vorlage:** Sichtbar wenn **Blitztext+** gewählt ist — Preset direkt im Hauptfenster wählen. Änderungen werden sofort mit dem Tray synchronisiert.
-- **Start/Stopp-Button:** Klick zum Starten oder Beenden einer Aufnahme.
-- **Abbruch:** Bricht die aktuelle Aufnahme ohne Transkription ab.
-- **Diktat / Verlauf:** Schnellzugriff auf den Diktat-Modus und den Transkript-Verlauf.
-- **Vorlesen / Einstellungen:** Öffnet das Vorlese-Fenster oder den Einstellungs-Dialog.
-
-*Das Fenster öffnet sich beim Start sowie über den Tray-Eintrag **Fenster anzeigen** oder einen Klick auf das Tray-Icon. Schließen versteckt das Fenster nur — die App läuft im Tray weiter.*
-
----
-
-## Diktat, Verlauf und Vorlesen
-
-Zusätzlich zu den Workflows bietet das Tool drei Komfort-Funktionen:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/history-en.png" alt="Verlauf" width="340">
-  <img src="docs/screenshots/linux/tts-en.png" alt="Vorlesen" width="340">
-  <br><br>
-</div>
-
-| Menüpunkt | Beschreibung |
-| :--- | :--- |
-| **Diktat-Modus** | Umschalter. Ist er aktiv, werden alle Transkripte als Diktat-Einträge gesammelt und einzeln als Markdown-Datei gespeichert. Im Verlauf erscheint dann eine Schaltfläche **Zusammenführen**, die alle Einträge kombiniert und in die Zwischenablage kopiert. |
-| **Verlauf…** | Öffnet ein Fenster mit den letzten Transkripten. Pro Eintrag: In Zwischenablage kopieren oder löschen. |
-| **Vorlesen…** | Lässt dir beliebigen Text vorlesen — lokal per **Piper TTS** (Standard) oder optional über **OpenAI Cloud-TTS** (inklusive Anbieter-, Stimmen- und Modellauswahl). Nutze die Schaltfläche **Exportieren**, um die Audioausgabe als Datei zu speichern. |
-
-> [!NOTE]
-> **Diktat-Notizen** werden ausschließlich in einen Ordner **innerhalb des Home-Verzeichnisses** geschrieben (Schutz gegen Pfad-Ausbruch), mit Berechtigungen `0o600`.
-
-> [!IMPORTANT]
-> **Piper TTS** muss für die Vorlesefunktion (sowie Stimmen) installiert sein:
-> ```bash
-> .venv/bin/pip install piper-tts
-> # Stimmen (.onnx + .onnx.json) nach ~/.local/share/piper-voices/ legen
-> ```
-> Fehlt Piper oder eine Stimme, zeigt das Vorlese-Fenster einen Installationshinweis; alle übrigen Funktionen bleiben nutzbar. Optionale Desktop-Benachrichtigungen nutzen `notify-send` (Paket `libnotify-bin`).
-
-> [!NOTE]
-> **OpenAI Cloud-TTS** ist eine optionale Alternative zu Piper. Voraussetzung: das `openai`-Paket (`.venv/bin/pip install openai`) und ein gültiger Key in der Umgebungsvariable `OPENAI_API_KEY` (siehe `secrets.env` unten). Beim ersten Umschalten auf den Anbieter „OpenAI Cloud" fragt das Vorlese-Fenster einmalig nach Bestätigung, da der eingegebene Text zur Synthese an die OpenAI-Server gesendet wird. Piper bleibt Standard und arbeitet vollständig lokal.
-
----
-
 ## Konfiguration
 
-Alles wird lokal und sicher unter `~/.config/blitztext-linux/config.json` gespeichert. Der OpenAI-Schlüssel wird nicht mehr in dieser Datei abgelegt, sondern aus einer Umgebungsvariable gelesen. Die Konfigurationsdatei lässt sich für erweiterte Prompt- und Workflow-Anpassungen direkt aus den Einstellungen öffnen: **Einstellungen → Allgemein → „Konfigurationsdatei öffnen"**.
+Alles wird lokal unter `~/.config/blitztext-linux/config.json` gespeichert. Diese Datei enthält keine Secrets — der OpenAI-/OpenRouter-Key wird aus einer Umgebungsvariable gelesen (siehe [Secrets](#secrets)). Die Konfigurationsdatei lässt sich direkt aus den Einstellungen öffnen: **Einstellungen → Allgemein → „Konfigurationsdatei öffnen"**.
 
 Der Einstellungs-Dialog hat drei Tabs:
 
@@ -339,7 +331,7 @@ Der Einstellungs-Dialog hat drei Tabs:
 </div>
 
 > [!IMPORTANT]
-> Die Konfigurationsdatei wird automatisch mit restriktiven Dateiberechtigungen (**`0o600` / `chmod 600`**) gespeichert. Der echte OpenAI-Key liegt stattdessen in `~/.config/blitztext-linux/secrets.env` oder wird als Umgebungsvariable bereitgestellt.
+> Die Konfigurationsdatei wird automatisch mit restriktiven Dateiberechtigungen (**`0o600` / `chmod 600`**) gespeichert.
 
 <details>
 <summary><b>Beispiel-Konfiguration & Felderklärung</b></summary>
@@ -382,7 +374,7 @@ Der Einstellungs-Dialog hat drei Tabs:
 - **language**: Transkriptions-Sprache (`de`, `en`) oder `auto`.
 - **ui_language**: Sprache der App-Oberfläche (`de` oder `en`). Standard: `de`. Änderungen greifen nach einem Neustart.
 - **backend**: `openai-whisper` oder `faster-whisper`.
-- **hotkey_mode**: 
+- **hotkey_mode**:
   - `toggle`: Einmal drücken startet, erneutes Drücken beendet.
   - `hold`: Aufnahme läuft solange der Hotkey gedrückt wird.
 - **transcription_hotkey**: Aufnahmetaste, die vom globalen Hotkey-Daemon überwacht wird. Standard: `KEY_LEFTALT`.
@@ -408,15 +400,66 @@ Der Einstellungs-Dialog hat drei Tabs:
 
 ---
 
-## Entwicklung und Tests
+## Secrets
 
-Wir lieben Stabilität! Führe die Tests lokal aus:
+API-Keys werden niemals in `config.json` gespeichert — sie werden zur Laufzeit aus Umgebungsvariablen gelesen.
+
+**Empfohlen: `secrets.env`.** Lege deine(n) Key(s) in `~/.config/blitztext-linux/secrets.env` ab, ein `NAME=WERT`-Paar pro Zeile, zum Beispiel:
+
+```bash
+OPENAI_API_KEY=sk-...
+# OPENROUTER_API_KEY=sk-or-...
+```
+
+`./run.sh` und der systemd-User-Service laden diese Datei automatisch. `config.json` speichert nur den *Namen* der zu lesenden Umgebungsvariable (`openai_api_key_env`), niemals den Key selbst.
+
+- Welche Variable verwendet wird, hängt von **Einstellungen → KI-Workflows → „API-Key-Umgebung"** und dem gewählten LLM-Anbieter ab (`OPENAI_API_KEY` für OpenAI, `OPENROUTER_API_KEY` für OpenRouter, oder ein eigener Name für einen eigenen Endpunkt).
+- Ohne gültigen Key sind die LLM-Workflows (`Blitztext+`, `Blitztext $%&!`, `Blitztext :)`) und OpenAI Cloud-TTS deaktiviert bzw. schlagen mit einer Fehlermeldung fehl; lokale Transkription und Piper-TTS funktionieren weiterhin.
+- Committe niemals `secrets.env`, API-Keys oder Tokens in git. Sollte ein Key jemals offengelegt werden (z. B. versehentlich committet oder in ein Issue eingefügt), rotiere ihn sofort beim Anbieter.
+- `config.json` wird mit restriktiven Rechten (`0o600`) geschrieben; die gleiche Erwartung gilt für `secrets.env`.
+
+---
+
+## Tests
+
+Führe die Test-Suite lokal aus:
 
 ```bash
 pytest
 ```
 
 Mit `WHISPER_GUI_TESTS=1 QT_QPA_PLATFORM=offscreen pytest` laufen zusätzlich die GUI-Tests (Hauptfenster, Compose-Fenster).
+
+`bash scripts/verify.sh` führt sitzungsabhängige Diagnosen für X11-, Wayland- und Clipboard-Backends aus — hilfreich nach der Installation oder bei der Fehlersuche zu Hotkeys/Paste-Verhalten. Die Ausgabe ist Diagnosehilfe, kein Supportversprechen; siehe die dort ausgegebenen Kompatibilitätshinweise für deine Desktop-Sitzung.
+
+---
+
+## Flatpak-MVP-Status
+
+`packaging/flatpak/` enthält einen **experimentellen** Flatpak-Manifest-Spike — kein Release-Kanal und nicht auf Flathub veröffentlicht.
+
+- Eine strukturelle Validierung (`flatpak-builder --show-manifest` / `--show-deps`) sowie ein vollständiger lokaler Build (inklusive Download von `org.kde.Platform`/`org.kde.Sdk` 6.8) waren auf einer Entwicklungsmaschine beide erfolgreich.
+- Die KDE-6.8-Runtime ist upstream als EOL markiert; sie baut und läuft für diesen MVP dennoch. Ein Runtime-Bump auf 6.10 ist ein möglicher Folge-Spike, hier aber nicht umgesetzt.
+- Innerhalb der Flatpak-Sandbox sind mehrere Funktionen bewusst deaktiviert oder eingeschränkt: keine globalen Hotkeys (kein evdev-/Input-Geräte-Zugriff), kein `ydotool`-Auto-Paste (Zwischenablage-Kopie funktioniert weiterhin über den Qt-Fallback), keine lokale Whisper-Transkription (aus `requirements-flatpak.txt` wegen der Größe ausgeklammert — Cloud-Transkription/LLM-Workflows funktionieren weiterhin mit `--share=network`) und keine Desktop-Benachrichtigungen (`notify-send` ist nicht gebündelt).
+- Es gibt kein Signing, keine AppStream-Metadaten, kein `.desktop`-File und kein paketiertes Release für diesen Spike.
+
+Details zu Manifest-Umfang, Build-Befehlen und bekannten Abweichungen von Flathub-Konventionen siehe [`packaging/flatpak/README.md`](packaging/flatpak/README.md).
+
+---
+
+## Bekannte Grenzen
+
+- **Linux Exclusive:** Nur für Linux-Systeme.
+- **Wayland Fokus:** Entwickelt für Wayland (`wl-clipboard`, `ydotool`).
+- **Datenschutz:** Lokale Workflows bleiben zu 100% auf deinem Rechner. OpenAI oder OpenRouter wird nur bei Bedarf für LLM- oder Cloud-TTS-Aufgaben kontaktiert.
+- **Sicherheit (`evdev` & `input`-Gruppe):** Das Tool liest Input global über `/dev/input/event*`. Auf System-Ebene bedeutet dies, dass alle Prozesse des Benutzers Eingaben mitlesen könnten (Trade-off unter Wayland ohne XDG GlobalShortcuts). Nutze Blitztext nur in Umgebungen, denen du vertraust!
+- **Flatpak-Sandbox:** Siehe [Flatpak-MVP-Status](#flatpak-mvp-status) oben — globale Hotkeys, Auto-Paste, lokales Whisper und Desktop-Benachrichtigungen sind innerhalb der Sandbox nicht verfügbar.
+
+---
+
+## Entwicklung
+
+Dieses Projekt wurde mit Unterstützung künstlicher Intelligenz (AI-assisted) entworfen. Architektur, Code und Tests wurden manuell gesichtet und auf Funktion/Sicherheit lokal verifiziert. Siehe [CONTRIBUTING.md](CONTRIBUTING.md) für Hinweise, wie du Änderungen vorschlagen kannst.
 
 <details>
 <summary><b>Verzeichnisüberblick</b></summary>
@@ -439,20 +482,11 @@ Mit `WHISPER_GUI_TESTS=1 QT_QPA_PLATFORM=offscreen pytest` laufen zusätzlich di
 │   ├── tts_window.py       # Vorlese-Fenster mit Audio-Export
 │   ├── workflows.py        # Workflow-Definitionen
 │   └── writing_presets.py  # Schreibstil-Vorlagen-Definitionen
+├── packaging/flatpak/      # Experimenteller Flatpak-MVP-Spike (siehe oben)
 ├── tests/                  # Test-Suite
 └── README.md               # Englische Fassung (diese Datei: README.de.md)
 ```
 </details>
-
----
-
-## Wichtige Hinweise
-
-- **Linux Exclusive:** Nur für Linux-Systeme.
-- **Wayland Fokus:** Entwickelt für Wayland (`wl-clipboard`, `ydotool`).
-- **Datenschutz:** Lokale Workflows bleiben zu 100% auf deinem Rechner. OpenAI oder OpenRouter wird nur bei Bedarf für LLM- oder Cloud-TTS-Aufgaben kontaktiert.
-- **Sicherheit (`evdev` & `input` Gruppe):** Das Tool liest Input global über `/dev/input/event*`. Auf System-Ebene bedeutet dies, dass alle Prozesse des Benutzers Eingaben mitlesen könnten (Trade-off unter Wayland ohne XDG GlobalShortcuts). Nutzen Sie Blitztext nur in Umgebungen, denen Sie vertrauen!
-- **Entwickler-Hinweis:** Dieses Projekt wurde mit Unterstützung künstlicher Intelligenz (AI-assisted) entworfen. Architektur, Code und Tests wurden manuell gesichtet und auf Funktion/Sicherheit lokal verifiziert.
 
 ---
 
@@ -471,7 +505,7 @@ Das Original-Projekt ist ein experimentelles, nicht-kommerzielles Open-Source-Pr
   <sub>Erstellt mit ❤️ (und ein bisschen KI-Hilfe).</sub>
 </div>
 
-### v0.8.1: Absichtstreue Prompts und bessere Diagnose
+### Neueste Release-Notizen (v0.8.1): Absichtstreue Prompts und bessere Diagnose
 
 Blitztext+ und die Schreibstil-Presets bewahren die Absicht der Eingabe jetzt konservativer. Sie sollen bei diktierten Arbeitsanweisungen oder Übergabe-Prompts keine Meetings, Teilnehmer, Empfänger, Rollen oder Ziele erfinden. E-Mail-Presets nutzen eine E-Mail-artige Struktur nur dann, wenn die Eingabe erkennbar als Nachricht an jemanden gemeint ist.
 

--- a/README.de.md
+++ b/README.de.md
@@ -404,11 +404,10 @@ Der Einstellungs-Dialog hat drei Tabs:
 
 API-Keys werden niemals in `config.json` gespeichert — sie werden zur Laufzeit aus Umgebungsvariablen gelesen.
 
-**Empfohlen: `secrets.env`.** Lege deine(n) Key(s) in `~/.config/blitztext-linux/secrets.env` ab, ein `NAME=WERT`-Paar pro Zeile, zum Beispiel:
+**Empfohlen: `secrets.env`.** Lege deine(n) Key(s) in `~/.config/blitztext-linux/secrets.env` ab, ein `NAME=WERT`-Paar pro Zeile — der Variablenname richtet sich nach dem unter **Einstellungen → KI-Workflows → „API-Key-Umgebung"** gewählten Anbieter (z. B. die OpenAI-Variable für OpenAI, die OpenRouter-Variable für OpenRouter), `WERT` ist der geheime Key von diesem Anbieter:
 
 ```bash
-OPENAI_API_KEY=sk-...
-# OPENROUTER_API_KEY=sk-or-...
+<VARIABLENNAME>=<dein-geheimer-wert>
 ```
 
 `./run.sh` und der systemd-User-Service laden diese Datei automatisch. `config.json` speichert nur den *Namen* der zu lesenden Umgebungsvariable (`openai_api_key_env`), niemals den Key selbst.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@
 
 ---
 
+## Purpose
+
+Blitztext Linux is a hotkey-driven voice assistant that turns speech into text and pastes it directly into whatever application has focus. Transcription runs locally via Whisper by default; an LLM step is optional and only used when you explicitly pick one of the AI workflows (rephrase, tone filter, emoji enrichment) or the Compose window. Everything is designed to stay on your machine unless you deliberately opt into a cloud provider (OpenAI, OpenRouter, or a custom OpenAI-compatible endpoint) for LLM or Cloud TTS features.
+
+---
+
 ## Features
 
 - **Multilingual interface (EN/DE):** Switch the app interface between German and English under **Settings → General → "Interface language"** (takes effect after restarting the app).
@@ -30,9 +36,180 @@
 - **LLM-powered workflows:** Let the AI rephrase your sentences professionally, filter them emotionally, or enrich them with fitting emojis.
 - **Local processing:** Optionally 100% offline for full privacy.
 
+### The 5 workflows and hotkeys
+
+Blitztext registers global hotkeys via `evdev`. With these combinations you have full control:
+
+| Workflow | Hotkey | LLM? | Description |
+| :--- | :--- | :---: | :--- |
+| **Blitztext** | <kbd>Meta</kbd> + <kbd>H</kbd> | ❌ | Default: records, transcribes, and pastes the text. |
+| **Blitztext Local** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd> | ❌ | Forces a pure **offline transcription**. |
+| **Blitztext+** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>T</kbd> | ✅ | Rephrases your recording professionally via LLM. |
+| **Blitztext $%&!** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> | ✅ | Emotional release: turns frustration into a matter-of-fact message. |
+| **Blitztext :)** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd> | ✅ | Enriches your message with fitting emojis. |
+
+> [!NOTE]
+> **LLM workflows** (`Blitztext+`, `Blitztext $%&!`, `Blitztext :)`) require a valid **API key**. See [Secrets](#secrets) below for how to configure it. Without a key, these functions are disabled in the menu and via hotkeys, or result in an error message.
+
+### AI workflows
+
+The AI workflows help with phrasing, tone, and emojis. You'll find the relevant settings under **Settings → AI Workflows**:
+
+<div align="center">
+  <img src="docs/screenshots/linux/settings-ai-workflows-en.png" alt="AI workflow settings" width="480">
+  <br><br>
+</div>
+
+**LLM providers.** Blitztext supports three provider modes, selectable under **Settings → AI Workflows → "LLM provider"**:
+
+| Provider | When to use |
+| :--- | :--- |
+| **OpenAI** (default) | Standard OpenAI API with `gpt-4o-mini` or any other model. |
+| **OpenRouter** | Access hundreds of models via a single API key (`OPENROUTER_API_KEY`). Base URL: `https://openrouter.ai/api/v1`. |
+| **Custom endpoint** | Any OpenAI-compatible API — set "Base URL" and "LLM model" to match your provider. |
+
+For OpenRouter, set `base_url` to `https://openrouter.ai/api/v1` and choose your model (e.g. `openai/gpt-4o`). The API key environment variable name is configured under "API key environment".
+
+**Writing-style presets.** For the **Blitztext+** workflow (text improver) there are ready-made writing-style presets that you select under **Settings → AI Workflows → "Writing-style preset"** or directly in the **Compose window**:
+
+| Preset | Effect |
+| --- | --- |
+| **Standard (improve text)** | Previous behavior – cleanly formatted text, the selected **tone** applies. |
+| **Email – formal** | Polite email in the formal form with a clear structure. |
+| **Email – casual** | Friendly email in the informal form. |
+| **Bullet points** | Structures the content into concise bullet points. |
+| **Summary** | Concise, factual summary of the key statements. |
+| **Personal (informal)** | Clear text in a personal, informal tone. |
+| **Polite (formal)** | Clear text in a polite, formal tone. |
+| **Short & precise** | As concise as possible, without filler words and repetitions. |
+| **Custom preset…** | A free-form system prompt you define yourself under **Settings → General → "Custom preset (Compose)"**. |
+
+> With **Standard**, the configured **tone** (casual / neutral / professional) is additionally applied. Every other preset brings its own writing style and overrides the tone setting. Custom names/terms are preserved in all presets.
+
+### Compose window
+
+The **Compose window** (`✍ Compose…` in the tray menu) lets you rewrite any text using the AI — without recording your voice. It is ideal for editing existing drafts, emails, or notes.
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/compose-en.png" alt="Compose window" width="480">
+  <br><br>
+</div>
+
+**How to open:** Click the tray icon → **✍ Compose…**
+
+**What you can do in the Compose window:**
+
+| Element | Description |
+| :--- | :--- |
+| **Draft (left pane)** | Type or paste the text you want to rewrite. |
+| **Workflow** | Choose between Blitztext+ (text improver), Blitztext $%&! (steam release), or Blitztext :) (emojis). |
+| **Writing-style preset** | Select a preset or **Custom preset…** for a fully custom system prompt. |
+| **Tone** | Choose casual, neutral, or professional. Active only when **Standard** preset + **Blitztext+** is selected; grayed out for all other presets (a tooltip explains why). |
+| **Improve** | Sends your draft to the AI and shows the result in the right pane. |
+| **Variant history** | The last 10 generated results within the current session are kept as a scrollable list — click any entry to restore it. |
+| **Signature** | Appends your saved signature (configured under **Settings → General**). Automatically replaces common AI-generated placeholders such as `[Your Name]`, `[Ihr Name]`, `[Vorname Nachname]`, `[Signature]`, and similar — so no stray placeholder is ever left behind. |
+| **Copy** | Copies the result to the clipboard. |
+| **Insert & Close** | Pastes the result directly into the active application and closes the window. |
+
+> [!NOTE]
+> The signature and custom preset text are configured under **Settings → General**. Set "Signature for Compose window" and toggle "Automatically append after generation" if you want the signature added to every result.
+
+### Tray icon and context menu
+
+The microphone in the system tray is your indicator of the current state:
+
+<div align="center">
+  <table>
+    <tr>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-idle.png" width="60"><br><br>
+        <b>Green</b> (IDLE)<br>
+        <i>Ready — waiting for your action.</i>
+      </td>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-recording.png" width="60"><br><br>
+        <b>Red</b> (RECORDING)<br>
+        <i>Recording is actively running.</i>
+      </td>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-processing.png" width="60"><br><br>
+        <b>Orange</b> (TRANSCRIBING)<br>
+        <i>Magic in progress (transcription / AI rephrasing).</i>
+      </td>
+      <td align="center" width="25%">
+        <img src="docs/screenshots/linux/tray-error.png" width="60"><br><br>
+        <b>Gray</b> (ERROR)<br>
+        <i>Oops, something went wrong.</i>
+      </td>
+    </tr>
+  </table>
+</div>
+
+The tray context menu gives you quick access to all workflows, the compose window, writing-style presets, dictation mode, history, and settings:
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/tray-menu-en.png" alt="Tray context menu" width="280">
+  <br><br>
+</div>
+
+> [!NOTE]
+> If no tray area is available in the desktop environment, the icon falls back to the system theme `audio-input-microphone`; the color coding may then not apply.
+
+### Main window
+
+The main window is your graphical control center — useful when hotkeys are blocked or you prefer mouse control:
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/main-window-en.png" alt="Main window" width="300">
+  <br><br>
+</div>
+
+- **Workflow dropdown:** Select from all 5 recording modes.
+- **Writing-style preset:** Visible when **Blitztext+** is selected — pick your preset directly in the main window. Changes sync to the tray instantly.
+- **Start/Stop button:** Click to begin or end a recording.
+- **Discard:** Cancels the current recording without transcription.
+- **Dictation / History:** Quick access to dictation mode and the transcript history.
+- **Read aloud / Settings:** Open the read-aloud window or the settings dialog.
+
+*The window opens at startup and via the tray entry **Show window** or a click on the tray icon. Closing only hides the window — the app keeps running in the tray.*
+
+### Dictation, history, and read-aloud
+
+In addition to the workflows, the tool offers three convenience functions:
+
+<div align="center">
+  <br>
+  <img src="docs/screenshots/linux/history-en.png" alt="History" width="340">
+  <img src="docs/screenshots/linux/tts-en.png" alt="Read aloud" width="340">
+  <br><br>
+</div>
+
+| Menu item | Description |
+| :--- | :--- |
+| **Dictation mode** | Toggle. When active, all transcripts are collected as dictation entries and each saved as a Markdown file. The history then shows a **Merge** button that combines all entries and copies them to the clipboard. |
+| **History…** | Opens a window with the most recent transcripts. Per entry: copy to clipboard or delete. |
+| **Read aloud…** | Reads any text aloud to you — locally via **Piper TTS** (default) or optionally via **OpenAI Cloud TTS** (including provider, voice, and model selection). Use the **Export** button to save the audio as a file. |
+
+> [!NOTE]
+> **Dictation notes** are written exclusively into a folder **inside the home directory** (protection against path traversal), with permissions `0o600`.
+
+> [!IMPORTANT]
+> **Piper TTS** must be installed for the read-aloud function (as well as voices):
+> ```bash
+> .venv/bin/pip install piper-tts
+> # Place voices (.onnx + .onnx.json) into ~/.local/share/piper-voices/
+> ```
+> If Piper or a voice is missing, the read-aloud window shows an installation hint; all other functions remain usable. Optional desktop notifications use `notify-send` (package `libnotify-bin`).
+
+> [!NOTE]
+> **OpenAI Cloud TTS** is an optional alternative to Piper. Requirements: the `openai` package (`.venv/bin/pip install openai`) and a valid key in the environment variable `OPENAI_API_KEY` (see [Secrets](#secrets) below). When first switching to the "OpenAI Cloud" provider, the read-aloud window asks for confirmation once, because the entered text is sent to OpenAI's servers for synthesis. Piper remains the default and works entirely locally.
+
 ---
 
-## Installation
+## Installation & Start
 
 ### Quick install (recommended)
 
@@ -138,197 +315,9 @@ systemctl --user enable --now ydotool.service   # uses /usr/local/bin/ydotoold
 
 ---
 
-## The 5 workflows and hotkeys
-
-Blitztext registers global hotkeys via `evdev`. With these combinations you have full control:
-
-| Workflow | Hotkey | LLM? | Description |
-| :--- | :--- | :---: | :--- |
-| **Blitztext** | <kbd>Meta</kbd> + <kbd>H</kbd> | ❌ | Default: records, transcribes, and pastes the text. |
-| **Blitztext Local** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>H</kbd> | ❌ | Forces a pure **offline transcription**. |
-| **Blitztext+** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>T</kbd> | ✅ | Rephrases your recording professionally via LLM. |
-| **Blitztext $%&!** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>D</kbd> | ✅ | Emotional release: turns frustration into a matter-of-fact message. |
-| **Blitztext :)** | <kbd>Meta</kbd> + <kbd>Shift</kbd> + <kbd>E</kbd> | ✅ | Enriches your message with fitting emojis. |
-
-> [!NOTE]
-> **LLM workflows** (`Blitztext+`, `Blitztext $%&!`, `Blitztext :)`) require a valid **API key**. The easiest way is to place it in `~/.config/blitztext-linux/secrets.env` using the format `NAME=VALUE` (e.g. `OPENAI_API_KEY` set to your key). `./run.sh` and the systemd service load this file automatically. Without a key, these functions are disabled in the menu and via hotkeys, or result in an error message.
-
----
-
-## AI workflows
-
-The AI workflows help with phrasing, tone, and emojis. You'll find the relevant settings under **Settings → AI Workflows**:
-
-<div align="center">
-  <img src="docs/screenshots/linux/settings-ai-workflows-en.png" alt="AI workflow settings" width="480">
-  <br><br>
-</div>
-
-### LLM providers
-
-Blitztext supports three provider modes, selectable under **Settings → AI Workflows → "LLM provider"**:
-
-| Provider | When to use |
-| :--- | :--- |
-| **OpenAI** (default) | Standard OpenAI API with `gpt-4o-mini` or any other model. |
-| **OpenRouter** | Access hundreds of models via a single API key (`OPENROUTER_API_KEY`). Base URL: `https://openrouter.ai/api/v1`. |
-| **Custom endpoint** | Any OpenAI-compatible API — set "Base URL" and "LLM model" to match your provider. |
-
-For OpenRouter, set `base_url` to `https://openrouter.ai/api/v1` and choose your model (e.g. `openai/gpt-4o`). The API key environment variable name is configured under "API key environment".
-
-### Writing-style presets
-
-For the **Blitztext+** workflow (text improver) there are ready-made writing-style presets that you select under **Settings → AI Workflows → "Writing-style preset"** or directly in the **Compose window**:
-
-| Preset | Effect |
-| --- | --- |
-| **Standard (improve text)** | Previous behavior – cleanly formatted text, the selected **tone** applies. |
-| **Email – formal** | Polite email in the formal form with a clear structure. |
-| **Email – casual** | Friendly email in the informal form. |
-| **Bullet points** | Structures the content into concise bullet points. |
-| **Summary** | Concise, factual summary of the key statements. |
-| **Personal (informal)** | Clear text in a personal, informal tone. |
-| **Polite (formal)** | Clear text in a polite, formal tone. |
-| **Short & precise** | As concise as possible, without filler words and repetitions. |
-| **Custom preset…** | A free-form system prompt you define yourself under **Settings → General → "Custom preset (Compose)"**. |
-
-> With **Standard**, the configured **tone** (casual / neutral / professional) is additionally applied. Every other preset brings its own writing style and overrides the tone setting. Custom names/terms are preserved in all presets.
-
----
-
-## Compose window
-
-The **Compose window** (`✍ Compose…` in the tray menu) lets you rewrite any text using the AI — without recording your voice. It is ideal for editing existing drafts, emails, or notes.
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/compose-en.png" alt="Compose window" width="480">
-  <br><br>
-</div>
-
-**How to open:** Click the tray icon → **✍ Compose…**
-
-**What you can do in the Compose window:**
-
-| Element | Description |
-| :--- | :--- |
-| **Draft (left pane)** | Type or paste the text you want to rewrite. |
-| **Workflow** | Choose between Blitztext+ (text improver), Blitztext $%&! (steam release), or Blitztext :) (emojis). |
-| **Writing-style preset** | Select a preset or **Custom preset…** for a fully custom system prompt. |
-| **Tone** | Choose casual, neutral, or professional. Active only when **Standard** preset + **Blitztext+** is selected; grayed out for all other presets (a tooltip explains why). |
-| **Improve** | Sends your draft to the AI and shows the result in the right pane. |
-| **Variant history** | The last 10 generated results within the current session are kept as a scrollable list — click any entry to restore it. |
-| **Signature** | Appends your saved signature (configured under **Settings → General**). Automatically replaces common AI-generated placeholders such as `[Your Name]`, `[Ihr Name]`, `[Vorname Nachname]`, `[Signature]`, and similar — so no stray placeholder is ever left behind. |
-| **Copy** | Copies the result to the clipboard. |
-| **Insert & Close** | Pastes the result directly into the active application and closes the window. |
-
-> [!NOTE]
-> The signature and custom preset text are configured under **Settings → General**. Set "Signature for Compose window" and toggle "Automatically append after generation" if you want the signature added to every result.
-
----
-
-## Tray icon and context menu
-
-The microphone in the system tray is your indicator of the current state:
-
-<div align="center">
-  <table>
-    <tr>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-idle.png" width="60"><br><br>
-        <b>Green</b> (IDLE)<br>
-        <i>Ready — waiting for your action.</i>
-      </td>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-recording.png" width="60"><br><br>
-        <b>Red</b> (RECORDING)<br>
-        <i>Recording is actively running.</i>
-      </td>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-processing.png" width="60"><br><br>
-        <b>Orange</b> (TRANSCRIBING)<br>
-        <i>Magic in progress (transcription / AI rephrasing).</i>
-      </td>
-      <td align="center" width="25%">
-        <img src="docs/screenshots/linux/tray-error.png" width="60"><br><br>
-        <b>Gray</b> (ERROR)<br>
-        <i>Oops, something went wrong.</i>
-      </td>
-    </tr>
-  </table>
-</div>
-
-The tray context menu gives you quick access to all workflows, the compose window, writing-style presets, dictation mode, history, and settings:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/tray-menu-en.png" alt="Tray context menu" width="280">
-  <br><br>
-</div>
-
-> [!NOTE]
-> If no tray area is available in the desktop environment, the icon falls back to the system theme `audio-input-microphone`; the color coding may then not apply.
-
----
-
-## Main window
-
-The main window is your graphical control center — useful when hotkeys are blocked or you prefer mouse control:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/main-window-en.png" alt="Main window" width="300">
-  <br><br>
-</div>
-
-- **Workflow dropdown:** Select from all 5 recording modes.
-- **Writing-style preset:** Visible when **Blitztext+** is selected — pick your preset directly in the main window. Changes sync to the tray instantly.
-- **Start/Stop button:** Click to begin or end a recording.
-- **Discard:** Cancels the current recording without transcription.
-- **Dictation / History:** Quick access to dictation mode and the transcript history.
-- **Read aloud / Settings:** Open the read-aloud window or the settings dialog.
-
-*The window opens at startup and via the tray entry **Show window** or a click on the tray icon. Closing only hides the window — the app keeps running in the tray.*
-
----
-
-## Dictation, history, and read-aloud
-
-In addition to the workflows, the tool offers three convenience functions:
-
-<div align="center">
-  <br>
-  <img src="docs/screenshots/linux/history-en.png" alt="History" width="340">
-  <img src="docs/screenshots/linux/tts-en.png" alt="Read aloud" width="340">
-  <br><br>
-</div>
-
-
-| Menu item | Description |
-| :--- | :--- |
-| **Dictation mode** | Toggle. When active, all transcripts are collected as dictation entries and each saved as a Markdown file. The history then shows a **Merge** button that combines all entries and copies them to the clipboard. |
-| **History…** | Opens a window with the most recent transcripts. Per entry: copy to clipboard or delete. |
-| **Read aloud…** | Reads any text aloud to you — locally via **Piper TTS** (default) or optionally via **OpenAI Cloud TTS** (including provider, voice, and model selection). Use the **Export** button to save the audio as a file. |
-
-> [!NOTE]
-> **Dictation notes** are written exclusively into a folder **inside the home directory** (protection against path traversal), with permissions `0o600`.
-
-> [!IMPORTANT]
-> **Piper TTS** must be installed for the read-aloud function (as well as voices):
-> ```bash
-> .venv/bin/pip install piper-tts
-> # Place voices (.onnx + .onnx.json) into ~/.local/share/piper-voices/
-> ```
-> If Piper or a voice is missing, the read-aloud window shows an installation hint; all other functions remain usable. Optional desktop notifications use `notify-send` (package `libnotify-bin`).
-
-> [!NOTE]
-> **OpenAI Cloud TTS** is an optional alternative to Piper. Requirements: the `openai` package (`.venv/bin/pip install openai`) and a valid key in the environment variable `OPENAI_API_KEY` (see `secrets.env` below). When first switching to the "OpenAI Cloud" provider, the read-aloud window asks for confirmation once, because the entered text is sent to OpenAI's servers for synthesis. Piper remains the default and works entirely locally.
-
----
-
 ## Configuration
 
-Everything is stored locally and securely under `~/.config/blitztext-linux/config.json`. The OpenAI key is not stored in this file but read from an environment variable. The configuration file can be opened directly from the settings: **Settings → General → "Open configuration file"**.
+Everything is stored locally under `~/.config/blitztext-linux/config.json`. This file holds no secrets — the OpenAI/OpenRouter key is read from an environment variable (see [Secrets](#secrets)). The configuration file can be opened directly from the settings: **Settings → General → "Open configuration file"**.
 
 The settings dialog has three tabs:
 
@@ -341,9 +330,8 @@ The settings dialog has three tabs:
   <br><i>General — Auto-Paste, dictation folder, history size, interface language, and signature.</i><br><br>
 </div>
 
-
 > [!IMPORTANT]
-> The configuration file is automatically saved with restrictive file permissions (**`0o600` / `chmod 600`**). The real OpenAI key instead lives in `~/.config/blitztext-linux/secrets.env` or is provided as an environment variable.
+> The configuration file is automatically saved with restrictive file permissions (**`0o600` / `chmod 600`**).
 
 <details>
 <summary><b>Example configuration & field explanation</b></summary>
@@ -386,7 +374,7 @@ The settings dialog has three tabs:
 - **language**: Transcription language (`de`, `en`) or `auto`.
 - **ui_language**: Language of the app interface (`de` or `en`). Default: `de`. Changes take effect after a restart.
 - **backend**: `openai-whisper` or `faster-whisper`.
-- **hotkey_mode**: 
+- **hotkey_mode**:
   - `toggle`: press once to start, press again to stop.
   - `hold`: recording runs as long as the hotkey is held.
 - **transcription_hotkey**: Recording key captured by the global hotkey daemon. Default: `KEY_LEFTALT`.
@@ -412,15 +400,66 @@ The settings dialog has three tabs:
 
 ---
 
-## Development and tests
+## Secrets
 
-We love stability! Run the tests locally:
+API keys are never stored in `config.json` — they are read from environment variables at runtime.
+
+**Recommended: `secrets.env`.** Place your key(s) in `~/.config/blitztext-linux/secrets.env`, one `NAME=VALUE` pair per line, for example:
+
+```bash
+OPENAI_API_KEY=sk-...
+# OPENROUTER_API_KEY=sk-or-...
+```
+
+`./run.sh` and the systemd user service load this file automatically. `config.json` only stores the *name* of the environment variable to read (`openai_api_key_env`), never the key itself.
+
+- Which variable is used depends on **Settings → AI Workflows → "API key environment"** and the selected LLM provider (`OPENAI_API_KEY` for OpenAI, `OPENROUTER_API_KEY` for OpenRouter, or a custom name for a custom endpoint).
+- Without a valid key, the LLM workflows (`Blitztext+`, `Blitztext $%&!`, `Blitztext :)`) and OpenAI Cloud TTS are disabled or fail with an error message; local transcription and Piper TTS keep working.
+- Never commit `secrets.env`, API keys, or tokens to git. If a key is ever exposed (e.g. committed by accident or pasted into an issue), rotate it immediately with the provider.
+- `config.json` is written with restrictive permissions (`0o600`); keep the same expectation for `secrets.env`.
+
+---
+
+## Tests
+
+Run the test suite locally:
 
 ```bash
 pytest
 ```
 
 With `WHISPER_GUI_TESTS=1 QT_QPA_PLATFORM=offscreen pytest`, the GUI tests (main window, compose window) run additionally.
+
+`bash scripts/verify.sh` runs session-aware diagnostics for X11, Wayland, and clipboard backends — useful after installation or when troubleshooting hotkeys/paste behavior. Its output is diagnostic guidance, not a support promise; see the compatibility notes it prints for your desktop session.
+
+---
+
+## Flatpak MVP status
+
+`packaging/flatpak/` contains an **experimental** Flatpak manifest spike — it is not a release channel and not published on Flathub.
+
+- A structural validation (`flatpak-builder --show-manifest` / `--show-deps`) and a full local build (including the `org.kde.Platform`/`org.kde.Sdk` 6.8 download) have both succeeded on a development machine.
+- The KDE 6.8 runtime is marked EOL upstream; it still builds and runs for this MVP. A runtime bump to 6.10 is a possible follow-up spike, not something implemented here.
+- Inside the Flatpak sandbox, several features are intentionally disabled or degraded: no global hotkeys (no evdev/input-device access), no `ydotool` auto-paste (clipboard copy still works via the Qt fallback), no local Whisper transcription (excluded from `requirements-flatpak.txt` due to its size — cloud transcription/LLM workflows still work with `--share=network`), and no desktop notifications (`notify-send` is not bundled).
+- No signing, no AppStream metadata, no `.desktop` file, and no packaged release exist for this spike.
+
+See [`packaging/flatpak/README.md`](packaging/flatpak/README.md) for the exact manifest scope, build commands, and known deviations from Flathub conventions.
+
+---
+
+## Known limitations
+
+- **Linux exclusive:** For Linux systems only.
+- **Wayland focus:** Developed for Wayland (`wl-clipboard`, `ydotool`).
+- **Privacy:** Local workflows stay 100% on your machine. OpenAI or OpenRouter is only contacted when needed for LLM or Cloud TTS tasks.
+- **Security (`evdev` & `input` group):** The tool reads input globally via `/dev/input/event*`. At the system level, this means all of the user's processes could read along with input (a trade-off under Wayland without XDG GlobalShortcuts). Only use Blitztext in environments you trust!
+- **Flatpak sandbox:** See [Flatpak MVP status](#flatpak-mvp-status) above — global hotkeys, auto-paste, local Whisper, and desktop notifications are unavailable inside the sandbox.
+
+---
+
+## Development
+
+This project was designed with the support of artificial intelligence (AI-assisted). Architecture, code, and tests were reviewed manually and verified locally for function/security. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to propose changes.
 
 <details>
 <summary><b>Directory overview</b></summary>
@@ -443,20 +482,11 @@ With `WHISPER_GUI_TESTS=1 QT_QPA_PLATFORM=offscreen pytest`, the GUI tests (main
 │   ├── tts_window.py       # Read Aloud window with audio export
 │   ├── workflows.py        # Workflow definitions
 │   └── writing_presets.py  # Writing-style preset definitions
+├── packaging/flatpak/      # Experimental Flatpak MVP spike (see above)
 ├── tests/                  # Test suite
 └── README.md               # This document (German version: README.de.md)
 ```
 </details>
-
----
-
-## Important notes
-
-- **Linux exclusive:** For Linux systems only.
-- **Wayland focus:** Developed for Wayland (`wl-clipboard`, `ydotool`).
-- **Privacy:** Local workflows stay 100% on your machine. OpenAI or OpenRouter is only contacted when needed for LLM or Cloud TTS tasks.
-- **Security (`evdev` & `input` group):** The tool reads input globally via `/dev/input/event*`. At the system level, this means all of the user's processes could read along with input (a trade-off under Wayland without XDG GlobalShortcuts). Only use Blitztext in environments you trust!
-- **Developer note:** This project was designed with the support of artificial intelligence (AI-assisted). Architecture, code, and tests were reviewed manually and verified locally for function/security.
 
 ---
 
@@ -475,7 +505,7 @@ The original project is an experimental, non-commercial open-source project unde
   <sub>Made with ❤️ (and a little AI help).</sub>
 </div>
 
-### v0.8.1: Intent-preserving prompts and diagnostics
+### Latest release notes (v0.8.1): Intent-preserving prompts and diagnostics
 
 Blitztext+ and the writing presets now preserve the user's intent more conservatively. They avoid inventing meetings, participants, recipients, roles, or goals when rewriting spoken work instructions or handover prompts. Email presets only use email-like structure when the input is clearly meant as a message to someone.
 

--- a/README.md
+++ b/README.md
@@ -404,11 +404,10 @@ The settings dialog has three tabs:
 
 API keys are never stored in `config.json` — they are read from environment variables at runtime.
 
-**Recommended: `secrets.env`.** Place your key(s) in `~/.config/blitztext-linux/secrets.env`, one `NAME=VALUE` pair per line, for example:
+**Recommended: `secrets.env`.** Place your key(s) in `~/.config/blitztext-linux/secrets.env`, one `NAME=VALUE` pair per line — the variable name matches the provider selected under **Settings → AI Workflows → "API key environment"** (e.g. the OpenAI variable for OpenAI, the OpenRouter variable for OpenRouter), and `VALUE` is the secret key you got from that provider:
 
 ```bash
-OPENAI_API_KEY=sk-...
-# OPENROUTER_API_KEY=sk-or-...
+<VARIABLE_NAME>=<your-secret-value>
 ```
 
 `./run.sh` and the systemd user service load this file automatically. `config.json` only stores the *name* of the environment variable to read (`openai_api_key_env`), never the key itself.

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -12,6 +12,11 @@ Absichtlich enthalten:
 - Audioaufnahme ueber PulseAudio-Socket
 - Cloud-Aufrufe (OpenAI: LLM-Workflows, ggf. Transkription/TTS) ueber
   `--share=network`
+- D-Bus-Zugriff auf `org.kde.StatusNotifierWatcher`
+  (`--talk-name=org.kde.StatusNotifierWatcher`) fuer das Tray-Icon --
+  siehe "Tray-Icon erfordert D-Bus-Talk-Name" unten, App startet
+  ausschliesslich als Tray-Icon (`app/blitztext_linux.py::setup_tray`),
+  ohne diese Berechtigung ist die GUI im Sandbox unerreichbar.
 
 Absichtlich **nicht** enthalten / sichtbar deaktiviert:
 - Globale Hotkeys (evdev) -- `app/hotkey_service.py` importiert `evdev` lazy
@@ -97,6 +102,25 @@ flatpak-builder --run /tmp/blitztext-flatpak-build \
   packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml \
   blitztext-linux.sh
 ```
+
+### Tray-Icon erfordert D-Bus-Talk-Name
+
+Beim ersten echten `flatpak run`-Testlauf (nach PR #48) blieb die App
+unerreichbar: kein Absturz, Prozess lief stabil (`flatpak ps` zeigte ihn),
+aber es erschien weder Tray-Icon noch Fenster. Ursache: Blitztext startet
+ausschliesslich als Tray-Icon (`app/blitztext_linux.py::setup_tray`, Zeile
+~645/673-781), das Hauptfenster oeffnet sich erst per Klick darauf. Ohne
+`--talk-name=org.kde.StatusNotifierWatcher` im Manifest kann Qt
+(`QDBusTrayIcon`, KDE-Style) das StatusNotifierItem nicht beim Watcher
+registrieren (`QDBusError("org.freedesktop.DBus.Error.ServiceUnknown")`
+im Log) -- damit gab es keinen Weg, die GUI ueberhaupt zu oeffnen.
+
+Fix: `--talk-name=org.kde.StatusNotifierWatcher` zu `finish-args`
+hinzugefuegt (kein breiterer `--socket=session-bus`, um beim
+Minimal-Rechte-Ansatz des MVP zu bleiben). Nach Rebuild + Neuinstallation
+registrierte sich das Tray-Item nachweisbar per D-Bus
+(`busctl --user call ... org.kde.StatusNotifierItem Title` lieferte
+`"Blitztext"`), kein `ServiceUnknown`-Fehler mehr im Log.
 
 ### KDE Platform/Sdk 6.8 -- EOL-Hinweis
 

--- a/packaging/flatpak/README.md
+++ b/packaging/flatpak/README.md
@@ -55,23 +55,61 @@ Absichtlich **nicht** enthalten / sichtbar deaktiviert:
 
 ## Verifikation (in diesem Spike durchgefuehrt)
 
-`flatpak-builder` 1.4.8 ist auf diesem Host vorhanden. Ein vollstaendiger
-Build (Download von `org.kde.Platform`/`org.kde.Sdk` 6.8, ca. 1,5 GB) wurde
-in diesem Diagnose-Pass **nicht** ausgefuehrt -- das waere ein groesserer,
-bestaetigungspflichtiger Download/Installationsschritt ausserhalb des
-Spike-Rahmens. Stattdessen nur strukturelle Validierung ohne Runtime-Install:
+`flatpak-builder` 1.4.8 ist auf diesem Host vorhanden. Zunaechst wurde nur
+strukturell validiert, ohne Runtime-Install:
 
 ```bash
 flatpak-builder --show-manifest packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
 flatpak-builder --show-deps packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
 ```
 
-## Naechster Schritt (nicht Teil dieses Spikes)
+Nach PR #48 wurde zusaetzlich ein echter Build (inkl. Download von
+`org.kde.Platform`/`org.kde.Sdk` 6.8, ca. 1,5 GB) erfolgreich getestet.
 
-Falls ein echter Build gewuenscht ist:
+### Hinweis: Build-State-Dir unter `/tmp`
+
+Wenn das Build-Verzeichnis unter `/tmp` liegt, kann `flatpak-builder`
+je nach Setup versuchen, seinen State-Ordner (`.flatpak-builder/`) relativ
+zum Home-Filesystem anzulegen. Da `/tmp` haeufig ein separates `tmpfs` ist,
+schlagen manche Operationen (z. B. `rofiles-fuse`/Hardlinks) ueber die
+Filesystem-Grenze fehl. Abhilfe: State-Dir explizit auf denselben
+Filesystem-Mountpoint wie das Build-Ziel legen, z. B.:
 
 ```bash
-flatpak install flathub org.kde.Platform//6.8 org.kde.Sdk//6.8
+--state-dir=/tmp/blitztext-flatpak-builder-state
+```
+
+### Beispiel-Build-Befehl (ohne `--install`)
+
+```bash
+flatpak install --user -y flathub org.kde.Platform//6.8 org.kde.Sdk//6.8
+flatpak-builder --force-clean \
+  --state-dir=/tmp/blitztext-flatpak-builder-state \
+  /tmp/blitztext-flatpak-build \
+  packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
+```
+
+Bewusst ohne `--install` -- der Build wird nur erzeugt, nicht in die lokale
+Flatpak-Umgebung installiert. Fuer einen manuellen Testlauf danach:
+
+```bash
+flatpak-builder --run /tmp/blitztext-flatpak-build \
+  packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml \
+  blitztext-linux.sh
+```
+
+### KDE Platform/Sdk 6.8 -- EOL-Hinweis
+
+Laut Flathub ist `org.kde.Platform`/`org.kde.Sdk` 6.8 als EOL markiert.
+Fuer diesen MVP ist die Runtime weiterhin funktionsfaehig und wurde
+erfolgreich gebaut. Naechster Upgrade-Kandidat: **6.10**. Ein Runtime-Bump
+ist nicht Teil dieses Spikes.
+
+## Naechster Schritt (nicht Teil dieses Spikes)
+
+Falls ein vollstaendig installierter Testlauf gewuenscht ist:
+
+```bash
 flatpak-builder --user --install --force-clean build-dir \
   packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
 flatpak run io.github.TimInTech.BlitztextLinux

--- a/packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
+++ b/packaging/flatpak/io.github.TimInTech.BlitztextLinux.yaml
@@ -16,6 +16,7 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --socket=pulseaudio
+  - --talk-name=org.kde.StatusNotifierWatcher
 
 modules:
   - name: blitztext-linux-deps


### PR DESCRIPTION
## Summary

* Refresh `README.md`, `README.de.md`, and the Flatpak build notes after the successfully built local Flatpak MVP.
* Allow the sandboxed application to register its tray icon through the narrowly scoped permission:
  `--talk-name=org.kde.StatusNotifierWatcher`.
* Fix the documentation examples that triggered the repository secret-hygiene scan.
* Keep the Flatpak MVP explicitly experimental: no Flathub submission, release, tag, version bump, desktop file, AppStream metadata, or icon packaging.

## Tray registration fix

Without access to `org.kde.StatusNotifierWatcher`, the Flatpak process started and remained alive, but no tray icon or reachable window appeared. Blitztext is tray-oriented, so this made the sandboxed application effectively inaccessible.

The manifest now grants only:

```text
--talk-name=org.kde.StatusNotifierWatcher
```

No broad session-bus permission was added.

Real verification after rebuild and installation:

* exactly one running Blitztext Flatpak instance
* StatusNotifierItem registered with title `Blitztext`
* no `org.freedesktop.DBus.Error.ServiceUnknown`
* successful shutdown with no remaining Flatpak instance
* existing native systemd-user instance remained untouched

## Documentation and CI fix

The secret-hygiene workflow rejected literal API-key examples in `README.md` and `README.de.md`. These examples were replaced with generic descriptions.

The workflow and `.github/secret-scan-patterns.txt` were not changed or weakened.

## Verification

* `python3 -m compileall app tests`
* `QT_QPA_PLATFORM=offscreen WHISPER_GUI_TESTS=1 python -m pytest -q`

  * `494 passed`
* `bash -n scripts/install.sh`
* `bash -n scripts/verify.sh`
* `git diff --check`
* repository secret scan using `.github/secret-scan-patterns.txt`
* real `flatpak-builder --user --install` build
* real Flatpak tray and D-Bus smoke test

## Scope exclusions

* no application-code changes
* no installer or service changes
* no desktop file, AppStream metadata, or icon
* no Flathub submission
* no version bump, tag, or release
* no Vault or roadmap changes

## Rollback

After a squash merge:

```bash
git revert <squash-commit>
```