### PR TITLE
docs: add prominent website link to READMEs

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -5,12 +5,17 @@
   <p><strong>Dein lokaler KI-Sprachassistent für KDE Plasma & Wayland</strong></p>
 
   <p>
+    <a href="https://timintech.github.io/blitztextweb/"><img src="https://img.shields.io/badge/🌐_Webseite-blitztextweb-2ea44f?style=for-the-badge" alt="Webseite"></a>
+  </p>
+
+  <p>
     <a href="https://github.com/TimInTech/blitztext-linux/actions/workflows/blitztext-linux-ci.yml"><img src="https://github.com/TimInTech/blitztext-linux/actions/workflows/blitztext-linux-ci.yml/badge.svg" alt="Blitztext Linux CI"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/Lizenz-MIT-yellow.svg" alt="Lizenz: MIT"></a>
     <img src="https://img.shields.io/badge/Plattform-Ubuntu%2FKubuntu%20%2B%20KDE%20Plasma-blue" alt="Plattform">
   </p>
   <p><a href="README.md">🇬🇧 English</a> | <strong>🇩🇪 Deutsch</strong></p>
   <p><i>Sprache per Hotkey aufnehmen, lokal oder online transkribieren, optional per LLM umschreiben und direkt in die aktive Anwendung einfügen.</i></p>
+  <p><strong>🔗 Webseite: <a href="https://timintech.github.io/blitztextweb/">timintech.github.io/blitztextweb</a></strong></p>
 </div>
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -5,12 +5,17 @@
   <p><strong>Your local AI voice assistant for KDE Plasma & Wayland</strong></p>
 
   <p>
+    <a href="https://timintech.github.io/blitztextweb/"><img src="https://img.shields.io/badge/🌐_Website-blitztextweb-2ea44f?style=for-the-badge" alt="Website"></a>
+  </p>
+
+  <p>
     <a href="https://github.com/TimInTech/blitztext-linux/actions/workflows/blitztext-linux-ci.yml"><img src="https://github.com/TimInTech/blitztext-linux/actions/workflows/blitztext-linux-ci.yml/badge.svg" alt="Blitztext Linux CI"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
     <img src="https://img.shields.io/badge/Platform-Ubuntu%2FKubuntu%20%2B%20KDE%20Plasma-blue" alt="Platform">
   </p>
   <p><strong>🇬🇧 English</strong> | <a href="README.de.md">🇩🇪 Deutsch</a></p>
   <p><i>Record speech via hotkey, transcribe locally or online, optionally rewrite it with an LLM, and paste it directly into the active application.</i></p>
+  <p><strong>🔗 Website: <a href="https://timintech.github.io/blitztextweb/">timintech.github.io/blitztextweb</a></strong></p>
 </div>
 
 > [!IMPORTANT]


### PR DESCRIPTION
## Summary
- Adds a prominent **Website** badge (`style=for-the-badge`) to the centered header of both `README.md` and `README.de.md`
- Adds a highlighted link line under the subtitle pointing to https://timintech.github.io/blitztextweb/

Both changes appear at the top of each README so the website is immediately visible.

## Test plan
- [ ] Verify badge and link render correctly on GitHub for `README.md`
- [ ] Verify badge and link render correctly on GitHub for `README.de.md`
- [ ] Confirm both links resolve to https://timintech.github.io/blitztextweb/

🤖 Generated with [Claude Code](https://claude.com/claude-code)